### PR TITLE
Add Github Actions to build docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,6 @@ jobs:
           # The folder containing your sphinx docs.
           docs-folder: . # default is docs/
           # The command used to build your documentation.
-          build-command: make html
+          build-command: "sphinx-build . ./html"
           # Run before the build command, you can use this to install system level dependencies, for example with "apt-get update -y && apt-get install -y perl"
-          pre-build-command: pip install -r requirements.txt
+          pre-build-command: "pip install -r requirements.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-          
+      - name: sets environment 
+        run: |
+          echo "GIT_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "LANGUAGE=en" >> $GITHUB_ENV               
       - name: Sphinx Docs build with ReadTheDocs Docker
         uses: DavidLeoni/readthedocs-to-actions@v1.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,12 @@ jobs:
           
       - name: Sphinx Docs build with ReadTheDocs Docker
         uses: DavidLeoni/readthedocs-to-actions@v1.2
+        with:
+          RTD_PRJ_NAME: bede-documentation        
+          GIT_URL: https://github.com/${{ github.repository }}.git
+          GIT_TAG: ${{ env.GIT_TAG }}
+          VERSION: ${{ env.VERSION }}
+          REQUIREMENTS: requirements.txt
+          LANGUAGE: ${{ env.LANGUAGE }}
+          RTD_HTML_SINGLE: false
+          RTD_HTML_EXT: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,11 @@ jobs:
           LANGUAGE: ${{ env.LANGUAGE }}
           RTD_HTML_SINGLE: false
           RTD_HTML_EXT: false
+      - name: Show workspace output
+        run: |        
+          tree -aC $GITHUB_WORKSPACE
       - name: Archive built docs
         uses: actions/upload-artifact@v2
         with:
           name: docs
-          path: $GITHUB_WORKSPACE
+          path: ${{ env.GITHUB_WORKSPACE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,5 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
           
-      - name: Sphinx Build
-        # You may pin to the exact commit or the version.
-        # uses: ammaraskar/sphinx-action@8b4f60114d7fd1faeba1a712269168508d4750d2
-        uses: ammaraskar/sphinx-action@0.4
-        with:
-          # The folder containing your sphinx docs.
-          docs-folder: . # default is docs/
-          # The command used to build your documentation.
-          build-command: "sphinx-build . ./html"
-          # Run before the build command, you can use this to install system level dependencies, for example with "apt-get update -y && apt-get install -y perl"
-          pre-build-command: "pip install -r requirements.txt"
+      - name: Sphinx Docs build with ReadTheDocs Docker
+        uses: DavidLeoni/readthedocs-to-actions@v1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+          
+      - name: Sphinx Build
+        # You may pin to the exact commit or the version.
+        # uses: ammaraskar/sphinx-action@8b4f60114d7fd1faeba1a712269168508d4750d2
+        uses: ammaraskar/sphinx-action@0.4
+        with:
+          # The folder containing your sphinx docs.
+          docs-folder: . # default is docs/
+          # The command used to build your documentation.
+          build-command: make html
+          # Run before the build command, you can use this to install system level dependencies, for example with "apt-get update -y && apt-get install -y perl"
+          pre-build-command: pip install -r requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: docs
-          path: ${{ env.GITHUB_WORKSPACE }}
+          path: bede-documentation-html-en-main.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,8 @@ jobs:
           LANGUAGE: ${{ env.LANGUAGE }}
           RTD_HTML_SINGLE: false
           RTD_HTML_EXT: false
+      - name: Archive built docs
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: $GITHUB_WORKSPACE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: docs
-          path: bede-documentation-html-en-main.zip
+          path: html


### PR DESCRIPTION
Docs are built and zipped up as a build artifact, so they can be downloaded and checked.

(We might want to squash this when merging to avoid the usual "Yet another attempt..." commit messages that come with a first attempt at CI builds.)