### PR TITLE
Small tweak to conda instructions to comment out rm -rf

### DIFF
--- a/software/index.rst
+++ b/software/index.rst
@@ -294,9 +294,8 @@ The following should get you set up with a working conda environment (replacing 
 
 ::
 
-    rm -rf ~/.conda .condarc
     export DIR=/nobackup/projects/<project>/$USER
-    rm -rf $DIR
+    # rm -rf ~/.conda .condarc $DIR/miniconda # Uncomment if you want to remove old env
     mkdir $DIR
     pushd $DIR
 


### PR DESCRIPTION
 - This is dangerous and should not be the default
 - Addresses some comments of  #22