### PR TITLE
Fix link for registration details

### DIFF
--- a/usage/index.rst
+++ b/usage/index.rst
@@ -9,12 +9,7 @@ Registering
 
 Access to the machine is based around projects:
 
--  To register a new project:
-
-   -  Principle Investigators at an N8 institution should see the advice
-      <here>
-   -  Principle Investigators at other institutions should see the
-      advice <here>
+-  To information on how to register a new project, please see https://n8cir.org.uk/supporting-research/facilities/bede/docs/bede_registrations/
 
 -  To create an account to use the system:
 

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -9,7 +9,7 @@ Registering
 
 Access to the machine is based around projects:
 
--  To information on how to register a new project, please see https://n8cir.org.uk/supporting-research/facilities/bede/docs/bede_registrations/
+-  For information on how to register a new project, please see https://n8cir.org.uk/supporting-research/facilities/bede/docs/bede_registrations/
 
 -  To create an account to use the system:
 


### PR DESCRIPTION
Links to info about registration were not pointing anywhere. Fix this with a link to our registrations page.