### PR TITLE
Add information about partition default and max runtimes

### DIFF
--- a/usage/index.rst
+++ b/usage/index.rst
@@ -259,12 +259,6 @@ requested:
   * - gpu
     - 01:00:00
     - 2-00:00:00
-  * - login
-    - 01:00:00
-    - 2-00:00:00
-  * - vis
-    - 41-15:00:00
-    - UNLIMITED
 
 Where, for example, `2-00:00:00` means 'two days, zero hours, zero minutes,
 and zero seconds'. These job time limits affect what will and won't be accepted

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -239,3 +239,34 @@ GPUs in more than one node to perform calculations. Example job script:
    bede-ddlrun python $CONDA_PREFIX/ddl-tensorflow/examples/keras/mnist-tf-keras-adv.py
 
    echo "end of job"
+
+Maximum Job Runtime
+~~~~~~~~~~~~~~~~~~~
+
+Partitions on Bede have default job times, and maximum job times that can be
+requested:
+
+.. list-table:: 
+  :widths: 1 1 1
+  :header-rows: 1
+
+  * - Partition Name
+    - Default Job Time
+    - Maximum Job Time
+  * - infer
+    - 01:00:00
+    - 2-00:00:00
+  * - gpu
+    - 01:00:00
+    - 2-00:00:00
+  * - login
+    - 01:00:00
+    - 2-00:00:00
+  * - vis
+    - 41-15:00:00
+    - UNLIMITED
+
+Where, for example, `2-00:00:00` means 'two days, zero hours, zero minutes,
+and zero seconds'. These job time limits affect what will and won't be accepted
+in the `--time` field of your job script: `--time` values above the partition
+maximum will result in your job submission being rejected.


### PR DESCRIPTION
Adds some information about Bede partition default and max job runtimes.

Adding this information had me wondering whether or not these have been set sensibly, particularly the max job time in the `login` partition and both the default and max job times in the `vis` partition.

Closes #12.