### PR TITLE
Publish documentation to GitHub Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish
+
+on:
+  # Only pushes to main should result in a publication.
+  push:
+    branches: [ main ]
+  # Or manual invocation from the Actions tab
+  workflow_dispatch:
+
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      # Install Python
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.8"
+      # Install Python dependencies via pip
+      - name: "Install dependencies"
+        run: |
+          pip install -r requirements.txt
+      # Build the documentation 
+      - name: "Build docs"
+        run: |
+          sphinx-build -W . ./html
+      # Deploy the documentation to the gh-pages branch of this repository.
+      # If using a custom domain, the cname option should be specified
+      # note that the gh-pages branch may need to exist prior to the first run of this action (with no parent commit)
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: html
+          # cname: 


### PR DESCRIPTION
As an alternative to read the docs, the documentation can be published to GitHub Pages via actions. This will remove the adverts seen on free RTD.

This adds a new GitHub Action workflow, Publish.yml, which on push to the `main` branch, builds the documentation and if the build is successfull the generated html is commited to the `gh-pages` branch. 

This will then be available via a github pages, initially at https://n8-cir-bede.github.io/documenation (I think). 
If this route is to be pursued, the workflow can be ammended to also set the `CNAME` option, allowing the documentation to be published at a custom (sub)domain, such as `bede-documentaion.n8cir.org.uk`?.

To demonstrate this worked, my fork's main repository currently contains a [(slightly modified) version of the action](https://github.com/ptheywood/bede-documentation/actions/workflows/publish.yml) demonstrating it works, which hosts the content at https://ptheywood.uk/bede-documentation/ (This will not be permanent). 

A similar example showing the use of a custom subdomain can be found at https://docs.flamegpu.com/, which sets `docs.flamegpu.com` as the `cname` on https://github.com/FLAMEGPU/FLAMEGPU2-doc.

Todo: 
+ [ ] Select the subdomain to use (discussions required)
+ [ ] Update the PR with the CNAME set.
+ [ ] Get the appropraite DNS settings applied (requires access from others) 
+ [ ] gh-pages may need to be enabeld in the repository settings (directed at the gh-pages) branch.

Once merged:  
+ [ ] Update RTD to redirect / link users to the canonincal CNAME url. 
+ [ ] Update website content which currently links to RTD to link to the subdomain cname. 

This will close #10 and close #8