### PR TITLE
Reduce toctree depth to improve feel of index

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -14,7 +14,7 @@ Site Contents
 =============
 
 .. toctree::
-   :maxdepth: -1
+   :maxdepth: 2
 
    hardware/index
    usage/index


### PR DESCRIPTION
Reduces the index toctree depth to 2 - keeps the main structural headers and subheaders, removes the detail headers and beyond.

Fixes #45