### PR TITLE
Add FAQ on MATLAB availability

### DIFF
--- a/faq/index.rst
+++ b/faq/index.rst
@@ -48,3 +48,8 @@ to recompute, should be store in the :code:`/projects/<project>` directory.
 
 .. note::
   Backups are **NOT** currently implemented on the :code:`/projects` filesystem!
+
+Is MATLAB available on Bede?
+----------------------------
+
+Unfortunately MATLAB is not available on Bede. MATLAB is not currently supported on IBM systems with a Power architecture.


### PR DESCRIPTION
Adds a question to let people that MATLAB is not available on Bede due to architecture incompatibility.

Closes #48 