### PR TITLE
Add NVHPC and NVCC documentation

### DIFF
--- a/software/index.rst
+++ b/software/index.rst
@@ -192,7 +192,7 @@ environment is helpful, and can be done on request.
 Compilers
 ---------
 
-All compiler modules set the ``CC``, ``CXX``, ``FC``, ``F90`` environment variables to appropriate values. These are commonly used by tools such as cmake and autoconf, so that by loading a compiler module its compilers are used by default.
+Most compiler modules set the ``CC``, ``CXX``, ``FC``, ``F90`` environment variables to appropriate values. These are commonly used by tools such as CMake and autoconf, so that by loading a compiler module its compilers are used by default.
 
 This can also be done in your own build scripts and make files. e.g.
 
@@ -229,6 +229,10 @@ Note that, as from LLVM 11.0.0, it provides a Fortran compiler called
 experimentation, it is still immature and ultimately relies on
 ``gfortran`` for its code generation. The ``lvm/11.0.0`` module therefore
 defaults to using the operating system provided ``gfortran``, instead.
+
+::
+
+   module load llvm/11.0.0
 
 
 BLAS/LAPACK

--- a/software/index.rst
+++ b/software/index.rst
@@ -217,6 +217,8 @@ offload support:
 
    module load gcc/10.2.0
 
+For further information please see the `GCC online documentation <https://gcc.gnu.org/onlinedocs/>`__.
+
 LLVM
 ~~~~
 
@@ -234,6 +236,7 @@ defaults to using the operating system provided ``gfortran``, instead.
 
    module load llvm/11.0.0
 
+For further information please see the `LLVM Releases <https://releases.llvm.org/>`__ for versioned documentation.
 
 NVIDIA HPC SDK
 ~~~~~~~~~~~~~~
@@ -243,12 +246,11 @@ It provides C, C++ and Fortran compilers, which include features enabling GPU ac
 
 It is provided for use on the system by the ``nvhpc`` module(s), such as ``nvhpc/20.9``, and provides the ``nvc``, ``nvc++`` and ``nvfortran`` compilers.   
 
-For further information please see the `NVIDIA HPC SDK Documentation Archive <https://docs.nvidia.com/hpc-sdk/archive/>`__.
-
 ::
 
    module load nvhpc/20.9
 
+For further information please see the `NVIDIA HPC SDK Documentation Archive <https://docs.nvidia.com/hpc-sdk/archive/>`__.
 
 CUDA / NVCC
 ~~~~~~~~~~~
@@ -257,12 +259,12 @@ CUDA / NVCC
 
 Unlike other compiler modules, the cuda modules do not set ``CC`` or ``CXX`` environment variables. This is because ``nvcc`` can be used to compile device CUDA code in conjunction with a range of host compilers, such as GCC or LLVM clang.
 
-For further information please see the `CUDA Toolkit Archive <https://developer.nvidia.com/cuda-toolkit-archive>`__.
-
 ::
 
    module load cuda/10.2.89
    module load cuda/10.1.243
+
+For further information please see the `CUDA Toolkit Archive <https://developer.nvidia.com/cuda-toolkit-archive>`__.
    
 BLAS/LAPACK
 -----------

--- a/software/index.rst
+++ b/software/index.rst
@@ -249,6 +249,21 @@ For further information please see the `NVIDIA HPC SDK Documentation Archive <ht
 
    module load nvhpc/20.9
 
+
+CUDA / NVCC
+~~~~~~~~~~~
+
+`CUDA <https://developer.nvidia.com/cuda-zone>`__ and the ``nvcc`` CUDA/C++ compiler are provided for use on the system by the `cuda` modules.
+
+Unlike other compiler modules, the cuda modules do not set ``CC`` or ``CXX`` environment variables. This is because ``nvcc`` can be used to compile device CUDA code in conjunction with a range of host compilers, such as GCC or LLVM clang.
+
+For further information please see the `CUDA Toolkit Archive <https://developer.nvidia.com/cuda-toolkit-archive>`__.
+
+::
+
+   module load cuda/10.2.89
+   module load cuda/10.1.243
+   
 BLAS/LAPACK
 -----------
 

--- a/software/index.rst
+++ b/software/index.rst
@@ -235,6 +235,20 @@ defaults to using the operating system provided ``gfortran``, instead.
    module load llvm/11.0.0
 
 
+NVIDIA HPC SDK
+~~~~~~~~~~~~~~
+
+The `NVIDIA HPC SDK <https://developer.nvidia.com/hpc-sdk>`__, otherwise referred to as `nvhpc`, is a suite of compilers, libraries and tools for HPC.
+It provides C, C++ and Fortran compilers, which include features enabling GPU acceleration through standard C++ and Fortran, OpenACC directives and CUDA.
+
+It is provided for use on the system by the ``nvhpc`` module(s), such as ``nvhpc/20.9``, and provides the ``nvc``, ``nvc++`` and ``nvfortran`` compilers.   
+
+For further information please see the `NVIDIA HPC SDK Documentation Archive <https://docs.nvidia.com/hpc-sdk/archive/>`__.
+
+::
+
+   module load nvhpc/20.9
+
 BLAS/LAPACK
 -----------
 

--- a/software/index.rst
+++ b/software/index.rst
@@ -246,6 +246,8 @@ It provides C, C++ and Fortran compilers, which include features enabling GPU ac
 
 It is provided for use on the system by the ``nvhpc`` module(s), such as ``nvhpc/20.9``, and provides the ``nvc``, ``nvc++`` and ``nvfortran`` compilers.   
 
+This module also provides the `NCCL <https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/index.html>`__ and `NVSHMEM <https://docs.nvidia.com/hpc-sdk/nvshmem/index.html>`__ libraries, as well as the suite of math libraries typically included with the CUDA Toolkit, such as ``cublas``, ``cufft`` and ``nvblas``.
+
 ::
 
    module load nvhpc/20.9


### PR DESCRIPTION
+ Adds basic docs for the `nvhpc` module (closes #41)
    + Mentions `NCCL`, `NVSHMEM` and other libraries shipped with nvhpc
+ Adds basic docs for the `cuda` module (which provides the `nvcc` compiler) (closes #52)
+ Adds external links to GCC and LLVM documentation.

