### PR TITLE
Adjust Navigation / top level section ordering

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -70,9 +70,9 @@ html_theme_options = {
     'navbar_title': " ",
     'navbar_site_name': "Contents",
     'navbar_links': [
+        ("Usage", "usage/index"),
         ("Hardware", "hardware/index"),
         ("Software", "software/index"),
-        ("Usage", "usage/index"),
         ("Profiling", "profiling/index"),
         ("Training", "training/index"),
         ("User Group", "bug/index"),

--- a/index.rst
+++ b/index.rst
@@ -16,8 +16,8 @@ Site Contents
 .. toctree::
    :maxdepth: 2
 
-   hardware/index
    usage/index
+   hardware/index
    software/index
    profiling/index
    training/index

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -1,5 +1,5 @@
-Usage
-=====
+Using Bede
+==========
 
 Bede is running Red Hat Enterprise Linux 7 and access to its
 computational resources is mediated by the Slurm batch scheduler.


### PR DESCRIPTION
Promotes `Usage` ahead of `Hardware` and `Software` in the navigation and home page ToC. 

Arguably `Software` is also more important than `Hardware` from a web documentation perspective (The Software section will see more traffic than the Hardware section, which will never change)