### PR TITLE
Fix for PyTorch reset env instructions

### DIFF
--- a/software/index.rst
+++ b/software/index.rst
@@ -335,7 +335,7 @@ The following should get you set up with a working conda environment (replacing 
 ::
 
     export DIR=/nobackup/projects/<project>/$USER
-    # rm -rf ~/.conda .condarc $DIR/miniconda # Uncomment if you want to remove old env
+    # rm -rf ~/.conda ~/.condarc $DIR/miniconda # Uncomment if you want to remove old env
     mkdir $DIR
     pushd $DIR
 


### PR DESCRIPTION
Removing the .condarc file is wrong currently.