### PR TITLE
Initial RHEL8 migration docs

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -236,11 +236,25 @@ select:-webkit-autofill:focus {
   }
 }
 
+/* Tone down the alert warning background colour a little. Not trivial to get a separate title/body background colour with the bootstrap theme.*/
+.alert-warning {
+  background: #f4af25;
+  color: #2c3e50;
+}
+
+.alert-warning a, 
+.alert-warning a:hover, 
+.alert-warning a:focus, 
+.alert-warning code {
+    color: #9e0000;  /* A dark red which provides good contrast against the orange background) */
+}
+
+
 @media (max-width: 1160px) {
   .navbar-header {
       float: none;
   }
-  .navbar-left,.navbar-right {
+.navbar-left, .navbar-right {
       float: none !important;
       margin-right: 0;
   }

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -126,19 +126,19 @@ code {
 }
 
 /* Previous and next links in sidebar are not inside a <ul> for some
-   reason. This lets us identify them but could be a bit flaky. */
-:not(ul) > li {
+   reason. */
+.bs-sidenav > li {
   list-style: none;
   display: inline-block;
   width: 49%;
   padding: 10px 10px;
 }
 
-:not(ul) > li a {
+.bs-sidenav > li a {
   display: block;
 }
 
-:not(ul) > li a[title^=Next] {
+.bs-sidenav > li a[title^=Next] {
   text-align: right;
 }
 

--- a/common/rhel8-status.rst
+++ b/common/rhel8-status.rst
@@ -1,0 +1,4 @@
+.. note::
+   Bede's OS is being upgraded to RHEL8. This change may impact your use of Bede.
+
+   For more information please see :ref:`RHEL8 Migration page<RHEL8-migration>` for more information.

--- a/conf.py
+++ b/conf.py
@@ -48,7 +48,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.rst']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.rst', "common/*.rst"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/index.rst
+++ b/index.rst
@@ -10,6 +10,8 @@ Feel free to add items of concern to the Github issues section.
 
 Please note that the system is still under active development, and so some functionality may temporarily break.
 
+.. include:: common/rhel8-status.rst
+
 Site Contents
 =============
 
@@ -24,3 +26,4 @@ Site Contents
    faq/index
    bug/index
    glossary/index
+   rhel8/index

--- a/rhel8/index.rst
+++ b/rhel8/index.rst
@@ -1,0 +1,121 @@
+.. _RHEL8-migration:
+
+RHEL8 Migration
+===============
+
+Bede is in the process of an Operating System upgrade from Red Hat Enterprise Linux 7 (RHEL 7) to Red Hat Enterprise Linux 8 (RHEL 8).
+
+This upgrade will improve system security and enable the use of newer software versions, such as CUDA 11.
+
+However, it may impact your use of Bede:
+
+* The vendor-supplied set of modules will be removed
+* Multi-node IBM WMLCE functionality is not supported on RHEL 8
+* User-installed applications (particularly MPI programs) will likely need recompiling.
+
+Migration Process
+-----------------
+
+The migration from RHEL 7 to RHEL 8 has three mains steps:
+
+1. Users to test the RHEL 8 image
+2. Login nodes migrate to RHEL 8
+3. Compute nodes migrate to RHEL 8 as load permits
+
+
+Two new commands have been added to Bede for the duration of the OS migration: ``login8`` and ``login7``.
+
+* ``login8`` will connect you to a RHEL 8 interactive session
+* ``login7`` will connect you to a RHEL 7 interactive session
+
+Jobs will run on the same RHEL version from which they were submit via ``sbatch``. 
+
+User Testing
+^^^^^^^^^^^^
+
+Initially 2 nodes from the ``gpu`` partition, and 1 node from the ``infer`` partition have been migrated to RHEL 8 for user testing. 
+A second ``infer`` node is reserved for interactive RHEL 8 sessions. 
+
+To opt-in to using the RHEL 8 image:
+
+1. Connect to the login nodes as usual
+2. Run the ``login8`` command to gain an interactive session on an RHEL 8 node
+3. Load modules, compile code or submit jobs as usual.
+
+You may need to change your module load commands in some cases (see :ref:`rhel8-module-changes`), 
+and will likely need to recompile your codes for use on RHEL 8 (particularly MPI codes).
+
+
+Login Node Migration
+^^^^^^^^^^^^^^^^^^^^
+
+Once the period of time for users to opt-in to using RHEL 8 to ensure there are no issues for their workflows has ended, Bede's two login nodes will be migrated to RHEL8.
+
+From this time, when you connect to Bede you will immediately be connected to RHEL 8 sessions on the login nodes, and the ``login8`` command will no longer be required.
+
+If you have not yet migrated your workflows to RHEL8, the ``login7`` command can be used to connect to an interactive session on a RHEL 7 login node.
+
+Compute Node Migration
+^^^^^^^^^^^^^^^^^^^^^^
+
+Once the login nodes have been migrated to RHEL 8, the remaining compute nodes will be migrated to RHEL 8 as demand allows.
+
+During this time the ``login7`` command will still be available for users to connect to a RHEL 7 interactive sessions to submit jobs to RHEL 7 compute nodes.
+
+Initially, the capacity for RHEL 8 jobs will be low, increasing as more nodes are migrated.
+
+Conversely, the capacity for RHEL 7 jobs will initially be high but will decrease over time.
+
+This will likely impact queue time for your jobs, and may prevent multi-node jobs from being scheduled if the requested number of nodes is not available for the RHEL version used.
+
+Module Changes
+--------------
+
+Most existing modules from the RHEL7 installation are available on RHEL8, with newer versions of some modules (CUDA, NVHPC, IBM XL) also available.
+
+There are however a few exceptions:
+
+* Singularity no longer requires a module load, it is available globally by default.
+* ``mvapich2/2.3.5`` is not provided on RHEL 8 images. ``mvapich2/2.3.5-2`` which is provided on both RHEL 7 and RHEL 8 should be used instead.
+* ``nvhpc/20.9`` is not available, replaced by ``nvhpc/21.5``.
+* ``spack/central`` is not available as a module. Spack can be installed per-user via ``git``. Please see the :ref:`Spack documentation <software-spack>` for more details.
+* ``slurm/19.05.7`` and ``19.05.7b`` are not available, with ``slurm/dflt`` loaded by default.
+* ``tools/1.0`` and ``tools/1.1`` are not available, with ``tools/1.2`` loaded by default.
+
+Checking Node Availability
+--------------------------
+
+As compute nodes are migrated from RHEL 7 to RHEL 8, the capacity for jobs using each images will vary, impacting queue time and the maximum size of multi-node jobs.
+
+Information on how many nodes are running RHEL 7 or RHEL 8 can be found using the ``ACTIVE_FEATURES`` format option of ``sinfo`` (``%b``):
+
+.. code-block:: bash
+
+   # See how many nodes in the gpu partition have the rhel7 or rhel8 feature
+   sinfo -o "%9P %.5a %.10l %.6D %15b %N" -p gpu
+
+   # See how many nodes in the infer partition have the rhel7 or rhel8 feature
+   sinfo -o "%9P %.5a %.10l %.6D %15b %N" -p infer
+
+
+Checking Batch Job Requested Image
+----------------------------------
+
+``squeue`` can show if jobs were submit from an RHEL 7 or RHEL 8 image, using the ``FEATURES`` format option ``%f``:
+
+.. code-block:: bash
+
+   # List queue information for $USER's jobs, including FEATURES (3rd column)
+   squeue -o "%.19i %.9P %.6f %.8a %.8j %.8u %.2t %.10M %.6D %C %R" -u $USER
+
+
+.. _rhel8-module-changes:
+
+Checking the RHEL version
+-------------------------
+
+If at any point you wish to check which version of RHEL you are currently using, you can use:
+
+.. code-block:: bash
+
+   cat /etc/redhat-release

--- a/rhel8/index.rst
+++ b/rhel8/index.rst
@@ -4,8 +4,7 @@ RHEL8 Migration
 ===============
 
 Bede is in the process of an Operating System upgrade from Red Hat Enterprise Linux 7 (RHEL 7) to Red Hat Enterprise Linux 8 (RHEL 8).
-
-This upgrade will improve system security and enable the use of newer software versions, such as CUDA 11.
+This upgrade will enable the use of newer software versions, such as CUDA 11.
 
 However, it may impact your use of Bede:
 

--- a/software/index.rst
+++ b/software/index.rst
@@ -1,6 +1,9 @@
 Software
 ========
 
+.. include:: ../common/rhel8-status.rst
+
+
 Environments
 ------------
 
@@ -91,6 +94,8 @@ which are not currently recommended:
 
 In both cases, executing ``rm ~/.application_environment`` and login
 again will return you to the default software environment.
+
+.. _software-spack:
 
 Spack
 ~~~~~

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -4,6 +4,8 @@ Using Bede
 Bede is running Red Hat Enterprise Linux 7 and access to its
 computational resources is mediated by the Slurm batch scheduler.
 
+.. include:: ../common/rhel8-status.rst
+
 Registering
 -----------
 


### PR DESCRIPTION
Adds a new page `/rhel8/` which describes the migration process, describes `login8` and `login7`, lists changes to modules and provides several useful commands for checking rhel7/8 node count status and job info.


Adjusts some CSS, to fix oredered lists in content and adjust warning block formatting (although info was used in the end). 

Adds a note block to the index, software and usage pages to make users aware of this change:

![image](https://user-images.githubusercontent.com/628937/145616326-19603048-4faf-498b-aaaa-ba31d1d4a496.png)

This addresses part of #73, although subsequent changes will still be required when key dates are known and to other areas of the docs where changes are required (I.e. easybuild is gone). 
