### PR TITLE
Fix RTD buillds post Software Sources version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # Define environment variables in the job
+    env:
+      # When building on RTD, conf.py has some conditional logic. Test building with this enabled.
+      READTHEDOCS: "True"
+      
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/conf.py
+++ b/conf.py
@@ -189,8 +189,8 @@ html_sidebars = {
 def setup(app):
     on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
     if on_rtd:
-        app.add_javascript('https://use.fontawesome.com/c79ff27dd1.js')
-        app.add_javascript('js/rtd-versions.js')
+        app.add_js_file('https://use.fontawesome.com/c79ff27dd1.js')
+        app.add_js_file('js/rtd-versions.js')
 
 # Control use of the shphinx-rediraffe plugin to generate redirect files for moved documentation.
 # This is only viable for whole-pages, not for any bookmarks within a page unfortunately.


### PR DESCRIPTION
#67 increased the sphinx version to no longer be several major version behind.

This change resulted in the RTD build failing, due to the use of a deprecated and removed sphinx function, which was only called when building on RTD.

This PR: 

+ Adjusts the GitHub Actions workflow to run as if it were an RTD build (i.e. it defines the required environment variable to trigger the behaviour)
+ Fixes the error