### PR TITLE
Faq email and improvements

### DIFF
--- a/common/acknowledging-bede.rst
+++ b/common/acknowledging-bede.rst
@@ -1,0 +1,4 @@
+   "This work made use of the facilities of the N8 Centre of Excellence in
+   Computationally Intensive Research (N8 CIR) provided and funded by the N8
+   research partnership and EPSRC (Grant No. EP/T022167/1). The Centre is
+   co-ordinated by the Universities of Durham, Manchester and York."

--- a/faq/index.rst
+++ b/faq/index.rst
@@ -2,9 +2,10 @@ FAQ
 =====
 
 This page contains answers to the questions most frequently asked by Bede
-users. The question list will be updated over time as more questions are
+users. 
+The question list will be updated over time as more questions are
 asked - if there is anything that you think should definitely be answered
-here, please let us know at <email.address@dur.ac.uk>.
+here, please let us know by `Opening an Issue on GitHub <https://github.com/N8-CIR-Bede/documentation/issues/new>`__ or by contacting your `local Bede RSE <https://n8cir.org.uk/supporting-research/facilities/bede/rse-support-bede/>`__ .
 
 How long can I run jobs for?
 ----------------------------

--- a/faq/index.rst
+++ b/faq/index.rst
@@ -10,14 +10,16 @@ here, please let us know by `Opening an Issue on GitHub <https://github.com/N8-C
 How long can I run jobs for?
 ----------------------------
 
-You can run jobs for a maximum of 48 hours, in either the `gpu` or `infer`
+You can run jobs for a maximum of 48 hours, in either the ``gpu`` or ``infer``
 partitions.
+This is detailed in the :ref:`Usage section of the documentation<usage-maximum-job-runtime>`.
 
 How can I acknowledge Bede in published or presented work?
 ----------------------------------------------------------------
 
-You can acknowledge Bede using the standard text that we provide. You can
-find this :ref:`here <usage-acknowledging-bede>`.
+You can acknowledge Bede using the standard text that we provide in :ref:`Acknowledging Bede<usage-acknowledging-bede>`:
+
+.. include:: /common/acknowledging-bede.rst
 
 How can I check my home directory quota?
 ----------------------------------------
@@ -28,14 +30,14 @@ You can use the following command:
 
   quota -s
 
-  Disk quotas for user klcm500 (uid 639800132): 
+  Disk quotas for user XXXXXX (uid YYYYYYYY): 
        Filesystem   space   quota   limit   grace   files   quota   limit   grace
   nfs.bede.dur.ac.uk:/nfs/users
                    79544K      0K  20480M            1071       0       0
 
 This tells me that, in this case, I have a limit of :code:`20480M`, and am 
-currently using :code:`79544K` across 1071 files. You can find more information
-about the Bede filesystems :ref:`here <usage-file-storage>`.
+currently using :code:`79544K` across 1071 files. 
+For more information on using Bede's filesystems see the :ref:`File Storage <usage-file-storage>` documentation.
 
 Where should I put project data?
 --------------------------------
@@ -53,39 +55,37 @@ to recompute, should be store in the :code:`/projects/<project>` directory.
 How do I get started with Bede?
 -------------------------------
 
-The 'Using Bede' page runs through how to get registered, how to log in to the
-machine and how to run jobs, a link to this page can be found :ref:`here
-<using-bede>`.
+The :ref:`Using Bede<using-bede>` page provides details on how to get registered, how to log in to the
+machine and how to run jobs.
 
 How can I add my own software?
 ------------------------------
 
-It is recommended that you use spack to extend the installed software on the
-system, there are instructions on how to do this :ref:`here <software-environments>`,
-along with further information about alternatives.
+It is recommended that you use :ref:`Spack<software-spack>` to extend the installed software on the system if possible.
 
+Alternatively, the software you wish to use may provide instructions on local installation, or `contact your local Bede RSE <https://n8cir.org.uk/supporting-research/facilities/bede/rse-support-bede/>`__ for further guidance.
 
 Is MATLAB available on Bede?
 ----------------------------
 
-Unfortunately MATLAB is not available on Bede. MATLAB is not currently supported on IBM systems with a Power architecture.
-It is possible to install Octave on Bede which can work as an alternative, although there is
+Unfortunately `MATLAB <https://www.mathworks.com/products/matlab.html>`__ is not available on Bede. MATLAB is not currently supported on IBM systems with a Power architecture.
+It is possible to install `Octave <https://www.gnu.org/software/octave/index>`__ on Bede which can work as an alternative, although there is
 currently no official support for this.
 
 
 How can I suggest improvements or contribute to this documentation?
 -------------------------------------------------------------------
 
-The Bede documentation is maintained on github at
-https://github.com/N8-CIR-Bede/documentation where we welcome you to add issues
+The Bede documentation is maintained on GitHub at
+`github.com/N8-CIR-Bede/documentation <https://github.com/N8-CIR-Bede/documentation>`__ where we welcome you to add issues
 or to contribute by following the instructions in the README file. 
 
 
 How can I get further help and support?
 ---------------------------------------
 Each institution has Research Software Engineer support for Bede, and you can
-find the support email address for your institution `here
+find the support email address for your institution `on the N8CIR website
 <https://n8cir.org.uk/supporting-research/facilities/bede/rse-support-bede/>`__.
-There is also a slack workspace that you can join to get further support and
+There is also a `slack workspace <https://n8cirbede.slack.com>`__ that you can join to get further support and
 contact the Bede user community. To request access, please e-mail: marion.weinzierl@durham.ac.uk.
 

--- a/index.rst
+++ b/index.rst
@@ -5,8 +5,8 @@ Bede is a supercomputer (otherwise known as an HPC system) run by the N8 group o
 
 The system has a specialist architecture, optimised for large memory problems on GPUs and for multi-node multi-gpu programs. This has a range of applications in Machine Learning and Imaging.
 
-The site encourages user contributions via `GitHub <https://github.com/DurhamARC/bede>`_.
-Feel free to add items of concern to the Github issues section.
+The site encourages user contributions via `GitHub <https://github.com/N8-CIR-Bede/documentation>`__.
+Feel free to add items of concern to the `GitHub Issues <https://github.com/N8-CIR-Bede/documentation/issues>`__.
 
 Please note that the system is still under active development, and so some functionality may temporarily break.
 

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -50,10 +50,7 @@ wherever the work is presented.
 
 We provide the following acknowledgement text, and strongly encourage its use:
 
-   "This work made use of the facilities of the N8 Centre of Excellence in
-   Computationally Intensive Research (N8 CIR) provided and funded by the N8
-   research partnership and EPSRC (Grant No. EP/T022167/1). The Centre is
-   co-ordinated by the Universities of Durham, Manchester and York."
+.. include:: /common/acknowledging-bede.rst
 
 Acknowledgement of Bede provides data that can be used to assess the facility's
 success and influences future funding decisions, so please ensure that you are
@@ -250,6 +247,8 @@ GPUs in more than one node to perform calculations. Example job script:
 .. warning::
 
    IBM PowerAI DDL is only supported on RHEL 7
+
+.. _usage-maximum-job-runtime:
 
 Maximum Job Runtime
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
+ Replaces the generic / invalid  email address on faq/index.rst (closes #70)
+ Adjusts RST and rephrases existing FAQ answers
  + Includes duplicating the ankowledging bede statement, but with only a single source in RST for simple maintenance.

 