### PR TITLE
Update available NVHPC, Nsight Systems and Nsight Compute versions

### DIFF
--- a/software/compilers/nvcc.rst
+++ b/software/compilers/nvcc.rst
@@ -24,6 +24,7 @@ Unlike other compiler modules, the cuda modules do not set ``CC`` or ``CXX`` env
 
 For further information please see the `CUDA Toolkit Archive <https://developer.nvidia.com/cuda-toolkit-archive>`__.
 
+``nvcc`` is also available within the :ref:`NVIDIA HPC SDK<software-compilers-nvhpc>` compiler tool chain.
 
 ``nvcc`` supports a wide range of command options, a full list of which can be found in the `NVCC Documentation <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-command-options>`__.
 

--- a/software/compilers/nvhpc.rst
+++ b/software/compilers/nvhpc.rst
@@ -17,6 +17,7 @@ This module also provides the `NCCL <https://docs.nvidia.com/deeplearning/nccl/u
    # RHEL 7 only
    module load nvhpc/20.9
    # RHEL 8 only 
+   module load nvhpc/22.1
    module load nvhpc/21.5
 
 For further information please see the `NVIDIA HPC SDK Documentation Archive <https://docs.nvidia.com/hpc-sdk/archive/>`__.

--- a/software/tools/nsight-compute.rst
+++ b/software/tools/nsight-compute.rst
@@ -11,16 +11,18 @@ You should use a versions of ``ncu`` that is at least as new as the CUDA toolkit
 
 .. code-block:: bash
 
+   module load nsight-compute/2022.1.0 # provides nsys 2022.1.0
    module load nsight-compute/2020.2.1 # provides nsys 2020.2.1
 
    # RHEL 7 only
-   module load nvhpc/20.5  # provides nsys 2020.1.0
+   module load nvhpc/20.9  # provides nsys 2020.1.0
 
    # RHEL 8 only
    module load cuda/11.5.1 # provides nsys 2021.3.1
    module load cuda/11.4.1 # provides nsys 2021.2.1
    module load cuda/11.3.1 # provides nsys 2021.1.1
    module load cuda/11.2.2 # provides nsys 2020.3.1
+   module load nvhpc/22.1  # provides nsys 2021.3.0
    module load nvhpc/21.5  # provides nsys 2021.1.0
 
 

--- a/software/tools/nsight-systems.rst
+++ b/software/tools/nsight-systems.rst
@@ -13,16 +13,18 @@ You should use a versions of ``nsys`` that is at least as new as the CUDA toolki
 
 .. code-block:: bash
 
+   module load nsight-systems/2022.1.1 # provides nsys 2022.1.1
    module load nsight-systems/2020.3.1 # provides nsys 2020.3.1
 
    # RHEL 7 only
-   module load nvhpc/20.5  # provides nsys 2020.3.1
+   module load nvhpc/20.9  # provides nsys 2020.3.1
 
    # RHEL 8 only
    module load cuda/11.5.1 # provides nsys 2021.3.3
    module load cuda/11.4.1 # provides nsys 2021.2.4
    module load cuda/11.3.1 # provides nsys 2021.1.3
    module load cuda/11.2.2 # provides nsys 2020.4.3
+   module load nvhpc/22.1  # provides nsys 2021.5.1
    module load nvhpc/21.5  # provides nsys 2021.2.1
 
 To generate an application timeline with Nsight Systems CLI (``nsys``):


### PR DESCRIPTION
+ `nsight-systems/2022.1.1` now available
+ `nsight-compute/2022.1.0` now available
+ `nvhpc/22.1` is now available, which also provides
  + `ncu` `2021.3.0`
  + `nsys` `2021.5.1`
+ Corrects available `nvhpc` version from ncu/nsys pages for RHEL 7 from `20.5` to `20.9`
+ Adds a crossref from nvcc to nvhpc.