### PR TITLE
Add date for final RHEL 7 node removal/migration

### DIFF
--- a/common/rhel8-status.rst
+++ b/common/rhel8-status.rst
@@ -1,5 +1,5 @@
 .. note::
 
-   Bede's Login nodes have now been migrated to RHEL 8. This change may impact your use of Bede.
+   The remaining RHEL 7 login environment and compute nodes are scheduled for removal on 2022-05-03.
 
    For more information please see :ref:`RHEL8 Migration page<RHEL8-migration>` for more information.

--- a/conf.py
+++ b/conf.py
@@ -96,7 +96,7 @@ html_theme_options = {
     # Reset the navigation bar footer (html)
     "extra_navbar": "",
     # Add an announcement bar, visible at the top of each page.
-    "announcement": "RHEL 8 Migration in Progress",
+    "announcement": "RHEL 8 Migration in Progress - RHEL 7 removal scheduled for 2022-05-03",
     # Add the traditional footer theme and sphinx acknowledgements
     "extra_footer": f"Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>."
 }

--- a/rhel8/index.rst
+++ b/rhel8/index.rst
@@ -21,6 +21,8 @@ The migration from RHEL 7 to RHEL 8 has three mains steps:
 2. :ref:`Login nodes migrate to RHEL 8<rhel8-login-migration>` (**Complete**)
 3. :ref:`Compute nodes migrate to RHEL 8 as load permits<rhel8-compute-migration>` (**In Progress**)
 
+   * Remaining RHEL 7 nodes scheduled for removal at **09:00 BST on 2022-05-03**
+
 
 Two new commands have been added to Bede for the duration of the OS migration: ``login8`` and ``login7``.
 
@@ -78,6 +80,10 @@ Conversely, the capacity for RHEL 7 jobs will initially be high but will decreas
 
 This will likely impact queue time for your jobs, and may prevent multi-node jobs from being scheduled if the requested number of nodes is not available for the RHEL version used.
 See :ref:`Checking Node Availability<rhel8-check-node-availability>` for instructions on how to check how many nodes are available for RHEL 8 and RHEL 7. 
+
+.. attention::
+
+   The opt-in RHEL 7 login environment and few remaining RHEL 7 compute nodes are scheduled for removal at 9am on Tuesday 3rd May.
 
 Module Changes
 --------------


### PR DESCRIPTION
Updates the RHEL 8 page, common status admonition and per-page announcment to include the scheduled date for RHEL 7 removal (2022-05-03).  