### PR TITLE
Update RHEL 8 migration status marking as complete

### DIFF
--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -4,7 +4,7 @@ so cannot use sphinx :ref: for output destination URIs relative to the current p
 Instead, find the appropriate link within the current page, to add the anchor to the announcement.
 */
 window.onload = function () {
-    expectedAnnouncementContent = "RHEL 8 Migration in Progress";
+    expectedAnnouncementContent = "RHEL 8 Migration";
     expectedAnchorContent = "RHEL 8 Migration";
     var elements = document.getElementsByClassName("announcement");
     for (var i = 0; i < elements.length; i++) {

--- a/common/rhel8-status.rst
+++ b/common/rhel8-status.rst
@@ -1,5 +1,0 @@
-.. note::
-
-   The remaining RHEL 7 login environment and compute nodes are scheduled for removal on 2022-05-03.
-
-   For more information see :ref:`RHEL8 Migration <RHEL8-migration>`.

--- a/conf.py
+++ b/conf.py
@@ -92,7 +92,7 @@ html_theme_options = {
     # Reset the navigation bar footer (html)
     "extra_navbar": "",
     # Add an announcement bar, visible at the top of each page.
-    "announcement": "RHEL 8 Migration in Progress - RHEL 7 removal scheduled for 2022-05-03",
+    "announcement": "RHEL 8 Migration Complete",
     # Add the traditional footer theme and sphinx acknowledgements
     "extra_footer": f"Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>."
 }

--- a/guides/index.rst
+++ b/guides/index.rst
@@ -8,8 +8,6 @@ These provide guidance related to the use of Bede, such as the use of profiling 
 
 If you notice any omissions, errors or have any suggested changes to the documentation please create an `Issue <https://github.com/N8-CIR-Bede/documentation/issues>`__ or open a `Pull Request <https://github.com/N8-CIR-Bede/documentation/pulls>`__ on GitHub. 
 
-.. include:: ../common/rhel8-status.rst
-
 .. toctree::
     :maxdepth: -1
     :glob:

--- a/index.rst
+++ b/index.rst
@@ -10,9 +10,6 @@ Feel free to add items of concern to the `GitHub Issues <https://github.com/N8-C
 
 Please note that the system is still under active development, and so some functionality may temporarily break.
 
-.. include:: common/rhel8-status.rst
-
-
 .. The TOC is required on the root document, but as we have alternate navigation it is not required, so can be hidden?
 
 .. toctree::

--- a/rhel8/index.rst
+++ b/rhel8/index.rst
@@ -3,8 +3,12 @@
 RHEL 8 Migration
 ================
 
-Bede is in the process of an Operating System upgrade from Red Hat Enterprise Linux 7 (RHEL 7) to Red Hat Enterprise Linux 8 (RHEL 8).
-This upgrade will enable the use of newer software versions, such as CUDA 11.
+.. admonition:: Migration Complete
+
+   The RHEL 8 migration process is now complete, with all login and compute nodes using the RHEL 8 environment.
+
+Bede has now completed the Operating System upgrade from Red Hat Enterprise Linux 7 (RHEL 7) to Red Hat Enterprise Linux 8 (RHEL 8).
+This upgrade enables the use of newer software versions, such as CUDA 11.
 
 However, it may impact your use of Bede:
 
@@ -19,10 +23,7 @@ The migration from RHEL 7 to RHEL 8 has three mains steps:
 
 1. :ref:`Users to test the RHEL 8 image<rhel8-user-testing>` (**Complete**)
 2. :ref:`Login nodes migrate to RHEL 8<rhel8-login-migration>` (**Complete**)
-3. :ref:`Compute nodes migrate to RHEL 8 as load permits<rhel8-compute-migration>` (**In Progress**)
-
-   * Remaining RHEL 7 nodes scheduled for removal at **09:00 BST on 2022-05-03**
-
+3. :ref:`Compute nodes migrate to RHEL 8 as load permits<rhel8-compute-migration>` (**Complete**)
 
 Two new commands have been added to Bede for the duration of the OS migration: ``login8`` and ``login7``.
 
@@ -63,7 +64,7 @@ The ``login7`` command will be usable to connect to an interactive session on a 
  
 .. note::
 
-   Login nodes have been migrated to RHEL 8, and Compute nodes are now being migrated as load demands. See :ref:`Compute Node Migration<rhel8-compute-migration>` for more information.
+   Login nodes migration is complete
 
 .. _rhel8-compute-migration:
 
@@ -81,9 +82,11 @@ Conversely, the capacity for RHEL 7 jobs will initially be high but will decreas
 This will likely impact queue time for your jobs, and may prevent multi-node jobs from being scheduled if the requested number of nodes is not available for the RHEL version used.
 See :ref:`Checking Node Availability<rhel8-check-node-availability>` for instructions on how to check how many nodes are available for RHEL 8 and RHEL 7. 
 
-.. attention::
+.. note::
 
-   The opt-in RHEL 7 login environment and few remaining RHEL 7 compute nodes are scheduled for removal at 9am on Tuesday 3rd May.
+   All compute nodes have now been migrated to RHEL 8. 
+
+   The RHEL 7 environment is no longer available
 
 Module Changes
 --------------

--- a/software/index.rst
+++ b/software/index.rst
@@ -8,8 +8,6 @@ These pages list software available on bessemer and/or instructions on how to in
 
 If you notice any omissions, errors or have any suggested changes to the documentation please create an `Issue <https://github.com/N8-CIR-Bede/documentation/issues>`__ or open a `Pull Request <https://github.com/N8-CIR-Bede/documentation/pulls>`__ on GitHub. 
 
-.. include:: ../common/rhel8-status.rst
-
 .. toctree::
     :maxdepth: 3
     :name: softwaretoc

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -3,10 +3,8 @@
 Using Bede
 ==========
 
-Bede is running Red Hat Enterprise Linux 7 and access to its
+Bede is running Red Hat Enterprise Linux 8 and access to its
 computational resources is mediated by the Slurm batch scheduler.
-
-.. include:: ../common/rhel8-status.rst
 
 Registering
 -----------


### PR DESCRIPTION
RHEL 7 specific content will be removed at a later time, leaving the page up for now for reference