### PR TITLE
Document the `leeds` project

### DIFF
--- a/software/projects/index.rst
+++ b/software/projects/index.rst
@@ -12,3 +12,4 @@ If you notice any omissions, errors or have any suggested changes to the documen
 
     hecbiosim
     ibm-collaboration
+    leeds

--- a/software/projects/leeds.rst
+++ b/software/projects/leeds.rst
@@ -1,0 +1,22 @@
+.. _software-projects-leeds:
+
+Leeds
+=====
+
+The ``leeds`` project on bede provides software modules provided by staff at the University of Leeds, available for all users of Bede.
+
+It currently provides:
+
+* ``@todo``
+
+Once the ``leeds`` module has been loaded, the software modules it provides are then available for use:
+
+.. code-block:: bash
+
+   # Load the leeds module
+   module load leeds
+   # Load the @todo module
+   module load @todo
+
+For more information on the provided packages, see the links above.
+


### PR DESCRIPTION
Adds documentation for the `leeds` collection of software modules

+ [ ] Add Leeds project page
  + [x] stub with basic usage
  + [ ] list/cross ref software (CryoEm/Relion?)
+ [ ] Add per-software pages if new
+ [ ] Update instructions for provided software which already has some docs


Closes #144 