### PR TITLE
Remove links to now defunct gpucomputing.shef.ac.uk

### DIFF
--- a/training/index.rst
+++ b/training/index.rst
@@ -33,7 +33,6 @@ General Training Material
 * `OpenACC Online Course (NVIDIA) <https://www.openacc.org/events/openacc-online-course-2018>`_
 * `NVIDIA OpenACC Advanced Training Material Container <https://ngc.nvidia.com/catalog/containers/hpc:openacc-training-materials>`_
 * `CUDA training at Oakridge (slides and lecture recording) <https://www.olcf.ornl.gov/cuda-training-series/>`_
-* Sheffield `One <http://gpucomputing.shef.ac.uk/education/sheffield_onedaycuda/>`_ or `Two <http://gpucomputing.shef.ac.uk/education/cuda/>`_ Day Introduction to CUDA Course (slides and labs)
 * `Sheffield Parallel Computing with GPUs taught module (slides, labs, lecture recordings) <https://paulrichmond.shef.ac.uk/teaching/COM4521/>`_ 
 * The `Power AI User Group Slack workspace <https://www.poweraiug.org/join/>`_ is very helpful for all sorts of questions about Power AI.
 


### PR DESCRIPTION
This website nolonger exists.

P.S. I've since taken over teaching Paul's module. Whilst his site is still live, the current website for the module has been moved to https://rse.shef.ac.uk/training/com4521/