### PR TITLE
Cleanup module versions to match current (2024-02-28) modules

### DIFF
--- a/software/applications/amber.rst
+++ b/software/applications/amber.rst
@@ -12,12 +12,11 @@ On Bede, AMBER is made available through the :ref:`HECBioSim Project <software-p
 
    # Load the hecbiosim project
    module load hecbiosim
-   # Load the desired version of amber, for the appropriate OS image
-   # RHEL 8:
-   module load amber/20-rhel8
-   # RHEL 7
+
+   # Load the desired version of amber
+   module load amber/20-large-system-mod
    module load amber/20
-  
+
 
 The HECBioSim project also provide `example bede job submission scripts for AMBER on their website <https://www.hecbiosim.ac.uk/access-hpc/example-submit-scripts/bede-scripts>`__.
 

--- a/software/applications/gromacs.rst
+++ b/software/applications/gromacs.rst
@@ -17,10 +17,8 @@ On Bede, GROMACS is made available through the :ref:`HECBioSim Project <software
    # Load the hecbiosim project
    module load hecbiosim
    
-   # Load the desired version of gromacs, for the appropriate RHEL image.
-   # RHEL 8
+   # Load the desired version of gromacs
    module load gromacs/2020.4-plumed-2.6.2-rhel8
-   module load gromacs/2021.1
    module load gromacs/2021.1-plumed-2.7.2-rhel8
    module load gromacs/2021.2-plumed-2.7.1-rhel8
    module load gromacs/2021.2-plumed-2.7.2-rhel8
@@ -29,11 +27,6 @@ On Bede, GROMACS is made available through the :ref:`HECBioSim Project <software
    module load gromacs/2022.0-rhel8
    module load gromacs/2022.2
    module load gromacs/2023.1
-
-   # RHEL 7
-   gromacs/2020.3
-   gromacs/2020.4-plumed-2.6.2
-   gromacs/2021.2
 
 
 The HECBioSim project also provide `example bede job submission scripts for GROMACS on their website <https://www.hecbiosim.ac.uk/access-hpc/example-submit-scripts/bede-scripts>`__.

--- a/software/applications/namd.rst
+++ b/software/applications/namd.rst
@@ -13,11 +13,12 @@ On Bede, NAMD is made available through the :ref:`HECBioSim Project <software-pr
 
    # Load the hecbiosim project
    module load hecbiosim
+
    # Load the desired version of namd
    module load namd
    module load namd/2.14-smp
-   module load namd/3.0-alpha7-singlenode
-   module load namd/3.0-alpha9-singlenode-rhel8
+   module load namd/3.0-alpha12-singlenode
+   module load namd/3.0-alpha9-singlenode
 
 
 For more information see the `NAMD User's Guide <https://www.ks.uiuc.edu/Research/namd/2.14/ug/>`__.

--- a/software/applications/openmm.rst
+++ b/software/applications/openmm.rst
@@ -14,6 +14,7 @@ On Bede, OpenMM is made available through the :ref:`HECBioSim Project <software-
 
    # Load the hecbiosim project
    module load hecbiosim
+   
    # Load the desired version of openmm
    module load openmm
    module load openmm/7.4.1-python3.7

--- a/software/applications/python.rst
+++ b/software/applications/python.rst
@@ -12,10 +12,6 @@ Conda is a cross-platform package and environment management system, which can p
 Python 2 is also available, but is no longer an officially supported version of python. 
 If you are still using python 2, upgrade to python 3 as soon as possible.
 
-.. note::
-
-    The ``python`` executable refers to ``python2`` on RHEL 7, but ``python3`` on RHEL 8 images. Consider using the more specific ``python3`` command.
-
 If you wish to use non-conda python, you should use `virtual environments <https://docs.python.org/3/library/venv.html>`__ to isolate your python environment(s) from the system-wide environment.
 This will allow you to install your own python dependencies via pip.
 

--- a/software/applications/pytorch.rst
+++ b/software/applications/pytorch.rst
@@ -56,7 +56,7 @@ Installation via the upstream Conda channel is not currently possible, due to th
 .. note::
    
    The :ref:`Open-CE<software-applications-open-ce>` distribution of PyTorch does not include IBM technologies such as DDL or LMS, which were previously available via :ref:`WMLCE<software-applications-wmlce>`. 
-   WMLCE is not supported on RHEL 8.
+   WMLCE is no longer supported.
 
 
 Further Information

--- a/software/applications/rust.rst
+++ b/software/applications/rust.rst
@@ -6,7 +6,7 @@ Rust
 The `Rust Programming Language <https://www.rust-lang.org/>`__ is a general purpose programming language designed for performance and safety.
 More information on features of the Rust programming language can be found on the `rustlang.org website <https://www.rust-lang.org/learn>`__.
 
-On Bede, Rust is available without the need to load any software modules under RHEL 8. 
+On Bede, Rust is available without the need to load any software modules. 
 
 The central installation includes:
 
@@ -21,12 +21,7 @@ To find the version of rust currently available, run:
 
     rustc --version
 
-.. note::
-
-    Rust is not centrally installed on RHEL 7 images. 
-
-
-If you require a different version of ``rustc`` than provided by the RHEL 8 Bede image, it should be possible to install locally into your ``/users`` directory, the ``/project`` or ``/nobackup`` file stores to avoid filling your users directory.
+If you require a different version of ``rustc`` than provided by default on Bede, it should be possible to install locally into your ``/users`` directory, the ``/project`` or ``/nobackup`` file stores to avoid filling your users directory.
 These methods have not been tested on Bede.
 
 This should be possible via :ref:`Spack<software-spack>` via the `rust spack package <https://spack.readthedocs.io/en/latest/package_list.html#rust>`__ which provides the rust programming language toolchain.

--- a/software/applications/tensorflow.rst
+++ b/software/applications/tensorflow.rst
@@ -52,7 +52,7 @@ For example, to verify that TensorFlow is available and print the version:
 .. note::
    
    The :ref:`Open-CE<software-applications-open-ce>` distribution of TensorFlow does not include IBM technologies such as DDL or LMS, which were previously available via :ref:`WMLCE<software-applications-wmlce>`. 
-   WMLCE is not supported on RHEL 8.
+   WMLCE is no longer supported.
 
 Further Information
 ~~~~~~~~~~~~~~~~~~~

--- a/software/applications/wmlce.rst
+++ b/software/applications/wmlce.rst
@@ -8,7 +8,7 @@ IBM WMLCE (End of Life)
    WMLCE was archived by IBM on 2020-11-10 and is no longer updated, maintained or supported.
    It is no longer available on bede due to the migration away from RHEL 7.
 
-   It has been replaced by :ref:`Open Cognitiive Environment (Open-CE) <software-applications-open-ce>`, a community driven software distribution for machine learning.
+   It has been replaced by :ref:`Open Cognitive Environment (Open-CE) <software-applications-open-ce>`, a community driven software distribution for machine learning.
 
    Open-CE does not not support all features of WMLCE.
    

--- a/software/applications/wmlce.rst
+++ b/software/applications/wmlce.rst
@@ -6,6 +6,7 @@ IBM WMLCE (End of Life)
 .. warning:: 
 
    WMLCE was archived by IBM on 2020-11-10 and is no longer updated, maintained or supported.
+   It is no longer available on bede due to the migration away from RHEL 7.
 
    It has been replaced by :ref:`Open Cognitiive Environment (Open-CE) <software-applications-open-ce>`, a community driven software distribution for machine learning.
 
@@ -14,13 +15,6 @@ IBM WMLCE (End of Life)
    Please refer to the :ref:`Open-CE <software-applications-open-ce>` documentation for more information.
 
    Alternatively, consider moving to upstream sources for python packages such as :ref:`Tensorflow <software-applications-tensorflow>` or :ref:`PyTorch<software-applications-pytorch>` where available.
-
-.. warning:: 
-
-   WMLCE 1.7 only supported RHEL 7.6 and 7.7.
-   It is unsupported on RHEL 8, and may not behave correctly once the RHEL 8 migration has completed. 
-
-   Consider migrating to :ref:`Open Cognitiive Environment (Open-CE) <software-applications-open-ce>`.
 
 `IBM WMLCE <https://www.ibm.com/support/pages/get-started-ibm-wml-ce>`__ was the *Watson Machine Learning Community Edition* - a software distribution for machine learning which included IBM technology previews such as `Large Model Support for TensorFlow <https://www.ibm.com/support/knowledgecenter/SS5SF7_1.7.0/navigation/wmlce_getstarted_tflms.html?view=kc#wmlce_getstarted_tflms>`__.
 WMLCE is also known as PowerAI.

--- a/software/applications/wmlce.rst
+++ b/software/applications/wmlce.rst
@@ -111,7 +111,7 @@ On Bede, this command is ``bede-ddlrun``. For example:
 
 .. warning::
 
-   IBM DDL is not supported on RHEL 8 and will likely error on use.
+   IBM DDL is no longer supported and will likely error on use.
    
    Consider migrating away from DDL via  :ref:`Open-CE<software-applications-open-ce>` and regular ``bede-mpirun``
 

--- a/software/compilers/gcc.rst
+++ b/software/compilers/gcc.rst
@@ -10,12 +10,15 @@ offload support:
 
 .. code-block:: bash
 
+   module load gcc/12.2
    module load gcc/10.2.0
    module load gcc/8.4.0
 
-The version of GCC which is distributed with RHEL is also packaged as the ``gcc/native`` module. 
-On RHEL 7 nodes, this is GCC ``4.8.5``. 
-On RHEL 8 nodes, this is GCC ``8.5.0``.
+The version of GCC which is distributed with RHEL is also packaged as the ``gcc/native`` module, providing GCC ``8.5.0``
+
+.. code-block:: bash
+
+   module load gcc/native
 
 .. code-block:: bash
 

--- a/software/compilers/gcc.rst
+++ b/software/compilers/gcc.rst
@@ -14,22 +14,10 @@ offload support:
    module load gcc/10.2.0
    module load gcc/8.4.0
 
-The version of GCC which is distributed with RHEL is also packaged as the ``gcc/native`` module, providing GCC ``8.5.0``
+The version of GCC which is distributed with RHEL is also packaged as the ``gcc/native`` module, providing GCC ``8.5.0``. This does not include CUDA offload support.
 
 .. code-block:: bash
 
    module load gcc/native
-
-.. code-block:: bash
-
-   # The GCC version provided by this module is RHEL specific.
-   module load gcc/native
-
-.. note::
-   Note that the default GCC provided by Red Hat Enterprise Linux 7 (4.8.5)
-   is quite old, will not optimise for the POWER9 processor (either use
-   POWER8 tuning options or use a later compiler), and does not have
-   CUDA/GPU offload support compiled in. The module ``gcc/native`` has been
-   provided to point to this copy of GCC.
 
 For further information please see the `GCC online documentation <https://gcc.gnu.org/onlinedocs/>`__.

--- a/software/compilers/ibmxl.rst
+++ b/software/compilers/ibmxl.rst
@@ -1,15 +1,10 @@
 IBM XL
 ------
 
-The `IBM XL C and C++ compiler family <https://www.ibm.com/products/c-and-c-plus-plus-compiler-family>`__ and `IBM XL Fortran compiler family <https://www.ibm.com/products/fortran-compiler-family>`__ are available on Bede.
-
-On RHEL 7, the IBM compilers are part of the default environment.
-
-On RHEL 8, the IBM compilers are provided by the ``xl`` module family:
+The `IBM XL C and C++ compiler family <https://www.ibm.com/products/c-and-c-plus-plus-compiler-family>`__ and `IBM XL Fortran compiler family <https://www.ibm.com/products/fortran-compiler-family>`__ are available on Bede, provided by the ``xl`` module family:
 
 .. code-block:: bash
 
-   # RHEL 8 Only
    module load xl
    module load xl/16.1.1
 

--- a/software/compilers/nvcc.rst
+++ b/software/compilers/nvcc.rst
@@ -7,18 +7,15 @@ CUDA and NVCC
 
 Unlike other compiler modules, the cuda modules do not set ``CC`` or ``CXX`` environment variables. This is because ``nvcc`` can be used to compile device CUDA code in conjunction with a range of host compilers, such as GCC or LLVM clang.
 
-
 .. code-block:: bash
 
    module load cuda
 
-   # RHEL 8 only
+   module load cuda/12.0.1
    module load cuda/11.5.1
    module load cuda/11.4.1
    module load cuda/11.3.1
    module load cuda/11.2.2
-
-   # RHEL 7 or RHEL 8
    module load cuda/10.2.89
    module load cuda/10.1.243
 
@@ -44,6 +41,10 @@ The C++ dialect used for host and device code can be controlled using the ``--st
 CUDA ``>= 11.0`` also accepts
 
 * ``c++17``
+
+CUDA ``>= 12.0`` also accepts
+
+* ``c++20``
 
 The default C++ dialect depends on the host compiler, with ``nvcc`` matching the default dialect by the host c++ compiler.
 
@@ -198,7 +199,7 @@ e.g. to use ``xlc++`` as the host compiler for the default CUDA module:
 
 .. code-block:: bash
 
-   module load xl # RHEL 8 only
+   module load xl
    module load cuda
 
    nvcc -ccbin $(which xlc++) --std=c++11 -o main main.cu

--- a/software/compilers/nvhpc.rst
+++ b/software/compilers/nvhpc.rst
@@ -14,9 +14,8 @@ This module also provides the `NCCL <https://docs.nvidia.com/deeplearning/nccl/u
 .. code-block:: bash
 
    module load nvhpc
-   # RHEL 7 only
-   module load nvhpc/20.9
-   # RHEL 8 only 
+
+   module load nvhpc/23.1
    module load nvhpc/22.1
    module load nvhpc/21.5
 

--- a/software/index.rst
+++ b/software/index.rst
@@ -3,7 +3,7 @@
 Software on Bede
 ================
 
-These pages list software available on bessemer and/or instructions on how to install and use software which is not centrally installed.
+These pages list software available on Bede and/or instructions on how to install and use software which is not centrally installed.
 
 
 If you notice any omissions, errors or have any suggested changes to the documentation please create an `Issue <https://github.com/N8-CIR-Bede/documentation/issues>`__ or open a `Pull Request <https://github.com/N8-CIR-Bede/documentation/pulls>`__ on GitHub. 

--- a/software/libraries/blas-lapack.rst
+++ b/software/libraries/blas-lapack.rst
@@ -20,6 +20,6 @@ Or for OpenBLAS:
 
 .. code-block:: bash
 
-   module load gcc openblas/6.2
+   module load gcc openblas/0.3.10
    $CC -o myprog myprog.c $N8CIR_LINALG_CFLAGS
 

--- a/software/libraries/boost.rst
+++ b/software/libraries/boost.rst
@@ -8,4 +8,5 @@ A centrally-installed version is available via the modules system, which can be 
 .. code-block:: bash
 
     module load boost
+    module load boost/1.81.0
     module load boost/1.74.0

--- a/software/libraries/mpi.rst
+++ b/software/libraries/mpi.rst
@@ -31,8 +31,6 @@ MVAPICH2 is provided by the `mvapich2` module(s):
 
 .. code-block:: bash
 
-   module load mvapich2
-   module load mvapich2/2.3.5
    module load mvapich2/2.3.5-2
 
 .. note::
@@ -41,15 +39,12 @@ MVAPICH2 is provided by the `mvapich2` module(s):
 
    For codes that require these features, we currently recommend using the ``mvapich2`` module.
 
-.. note::
-
-   The ``mvapich2/2.3.5-2`` module should be used rather than ``mvapich2/2.3.5``, which is only provided to support existing projects which depend on it.
-
-   Under RHEL 8, the ``mvapich2/2.3.5`` module is removed.
-
-
 We also offer the ``mvapich2-gdr/2.3.6`` module. This is a version of MVAPICH2 that is specifically designed for machines like Bede, providing optimised communications directly between GPUs - even when housed in different compute nodes.
 
 Unlike the ``openmpi`` and ``mvapich2`` modules, ``mvapich2-gdr`` does not adapt itself to the currently loaded compiler and CUDA modules. This version of the software was built using GCC 8.4.1 and CUDA 11.3.
+
+.. code-block:: bash
+   
+   module load mvapich2-gdr/2.3.6 gcc/8.4.0 cuda/11.3.1
 
 Further information can be found on the `MVAPICH2-GDR <http://mvapich.cse.ohio-state.edu/userguide/gdr/>`__ pages.

--- a/software/libraries/plumed.rst
+++ b/software/libraries/plumed.rst
@@ -19,11 +19,13 @@ On Bede, PLUMED is made available through the :ref:`HECBioSim Project <software-
 
    # Load the hecbiosim project
    module load hecbiosim
+   
    # Load the desired version of PLUMED
-   module load plumed
-   module load plumed/2.7.2-rhel8
    module load plumed/2.6.2-rhel8
-   module load plumed/2.6.2
+   module load plumed/2.7.1-rhel8
+   module load plumed/2.7.2-rhel8
+   module load plumed/2.7.3-rhel8
+   module load plumed/2.8.0-rhel8
 
 
 For more information see the `PLUMED Documentation <https://www.plumed.org/doc>`__.

--- a/software/tools/index.rst
+++ b/software/tools/index.rst
@@ -3,7 +3,7 @@
 Tools
 ================
 
-These pages list developer tools available on bessemer and / or instructions on how to install and use tools which are not centrally installed.
+These pages list developer tools available on Bede and / or instructions on how to install and use tools which are not centrally installed.
 
 If you notice any omissions, errors or have any suggested changes to the documentation please create an `Issue <https://github.com/N8-CIR-Bede/documentation/issues>`__ or open a `Pull Request <https://github.com/N8-CIR-Bede/documentation/pulls>`__ on GitHub. 
 

--- a/software/tools/make.rst
+++ b/software/tools/make.rst
@@ -8,7 +8,7 @@ Make
 Make gets its knowledge of how to build your program from a file called the makefile, which lists each of the non-source files and how to compute it from other files. When you write a program, you should write a makefile for it, so that it is possible to use Make to build and install the program.
 
 
-On Bede, ``make 3.82`` is provided by default (``4.2`` under RHEL8). 
+On Bede, ``make 4.2`` is provided by default. 
 A more recent version of ``make``, is provided by the ``make`` family of modules. 
 
 .. code-block:: bash

--- a/software/tools/nsight-compute.rst
+++ b/software/tools/nsight-compute.rst
@@ -13,19 +13,19 @@ You should use a versions of ``ncu`` that is at least as new as the CUDA toolkit
 
 .. code-block:: bash
 
-   module load nsight-compute/2022.1.0 # provides nsys 2022.1.0
-   module load nsight-compute/2020.2.1 # provides nsys 2020.2.1
+   module load nsight-compute/2022.4.1 # provides ncu 2022.4.1
+   module load nsight-compute/2022.1.0 # provides ncu 2022.1.0
+   module load nsight-compute/2020.2.1 # provides ncu 2020.2.1
 
-   # RHEL 7 only
-   module load nvhpc/20.9  # provides nsys 2020.1.0
+   module load cuda/12.0.1 # provides ncu 2022.4.1
+   module load cuda/11.5.1 # provides ncu 2021.3.1
+   module load cuda/11.4.1 # provides ncu 2021.2.1
+   module load cuda/11.3.1 # provides ncu 2021.1.1
+   module load cuda/11.2.2 # provides ncu 2020.3.1
 
-   # RHEL 8 only
-   module load cuda/11.5.1 # provides nsys 2021.3.1
-   module load cuda/11.4.1 # provides nsys 2021.2.1
-   module load cuda/11.3.1 # provides nsys 2021.1.1
-   module load cuda/11.2.2 # provides nsys 2020.3.1
-   module load nvhpc/22.1  # provides nsys 2021.3.0
-   module load nvhpc/21.5  # provides nsys 2021.1.0
+   module load nvhpc/23.1  # provides ncu 2022.4.0
+   module load nvhpc/22.1  # provides ncu 2021.3.0
+   module load nvhpc/21.5  # provides ncu 2021.1.0
 
 
 Consider compiling your CUDA application using ``nvcc`` with ``-lineinfo`` or ``--generate-line-info`` to generate line-level profile information.

--- a/software/tools/nsight-systems.rst
+++ b/software/tools/nsight-systems.rst
@@ -14,17 +14,17 @@ You should use a versions of ``nsys`` that is at least as new as the CUDA toolki
 
 .. code-block:: bash
 
+   module load nsight-systems/2023.1.1 # provides nsys 2023.1.1
    module load nsight-systems/2022.1.1 # provides nsys 2022.1.1
    module load nsight-systems/2020.3.1 # provides nsys 2020.3.1
 
-   # RHEL 7 only
-   module load nvhpc/20.9  # provides nsys 2020.3.1
-
-   # RHEL 8 only
+   module load cuda/12.0.1 # provides nsys 2022.4.2
    module load cuda/11.5.1 # provides nsys 2021.3.3
    module load cuda/11.4.1 # provides nsys 2021.2.4
    module load cuda/11.3.1 # provides nsys 2021.1.3
    module load cuda/11.2.2 # provides nsys 2020.4.3
+
+   module load nvhpc/23.1  # provides nsys 2022.5.1
    module load nvhpc/22.1  # provides nsys 2021.5.1
    module load nvhpc/21.5  # provides nsys 2021.2.1
 

--- a/software/tools/singularity.rst
+++ b/software/tools/singularity.rst
@@ -13,13 +13,10 @@ Container platforms allow users to create and use container images, which are se
    As Bede is a Power 9 Architecture (``ppc64le``) machine, containers created on more common ``x86_64`` machines may not be compatible. 
 
 
-Under RHEL 8, Singularity is provided in the default environment, and can be used without loading any modules.
+Under RHEL 8, Singularity-ce is provided by default, and can be used without loading any modules.
 
-Under RHEL 7, singularity is provided by a module:
+.. code-block::bash
 
-.. code-block:: bash
-
-    module load singularity
-    module load singularity/3.6.4
+   singularity --version
 
 For more information on how to use singularity, please see the `Singularity Documentation <https://apptainer.org/docs-legacy/>`__.

--- a/software/tools/singularity.rst
+++ b/software/tools/singularity.rst
@@ -13,7 +13,7 @@ Container platforms allow users to create and use container images, which are se
    As Bede is a Power 9 Architecture (``ppc64le``) machine, containers created on more common ``x86_64`` machines may not be compatible. 
 
 
-Under RHEL 8, Singularity-ce is provided by default, and can be used without loading any modules.
+Singularity-ce is provided by default, and can be used without loading any modules.
 
 .. code-block::bash
 


### PR DESCRIPTION
Remove modules that were RHEL 7 only, leaving just RHEL 8 modules. 

Newer versions of modules up to 2024-02-28 have been added.
