### PR TITLE
Sphinx and theme upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: "actions/setup-python@v5"
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - name: "Install dependencies"
         run: pip install -r requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Using feature branches is recommended.
 Installing Dependencies
 ***********************
 
-This documentation requires ``python`` and a number of python packages as listed in ``requirements.txt``.
+This documentation requires ``python >= 3.9`` and a number of python packages as listed in ``requirements.txt``.
 This would be typically done using a `Python Virtual Environment <https://docs.python.org/3/tutorial/venv.html>`_, or `conda <https://docs.conda.io/en/latest/>`_
 
 
@@ -52,7 +52,7 @@ From a conda-enabled terminal:
 
 .. code-block:: console
 
-    conda create --name bede python=3
+    conda create --name bede python=3.9
     conda activate bede
     pip install -r requirements.txt
 

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1,53 +1,41 @@
 @import url('https://fonts.googleapis.com/css?family=Montserrat');
 /* Define N8 theme colours (and lighter versions) */
 :root {
-  --burnt-orange-color: #F95423;
-  --burnt-orange-color-a11y: #D13505;
-  --deep-blue-color: #054C91;
-  --cool-grey-10-color: #63666A;
-  --cool-grey-6-color: #A7A8AA;
-  --cool-grey-5-color: #b1b3b3;
-  --cool-grey-4-color: #bbbcbc;
-  --cool-grey-3-color: #c8c9c7;
-  --cool-grey-2-color: #D0D0CE;
-  --cool-grey-2-lighter-color: #E1E1E0; /* equivalent of Cool grey 2 with alpha 0.5 */
-  --cool-grey-2-lightest-color: #F1F1F0; /* equivalent of Cool grey 2 with alpha 0.3 */
-  --burnt-orange-lightest-color: #FFF6F5; /* equivalent of burnt orange with alpha 0.05 */
-  --general-background-color: #f5f5f5;
-  --general-text-color: #212529;
-  /* Override some variable defined in the sphinx-book-theme, as a simpler solution for quick colour changing */
-  --pst-color-link: 5,76,145; /* Equivalent to #054c91, deep-blue-color */
-  --pst-color-preformatted-background: 248,248,248; /* pygments default pre background */
-  --pst-sidebar-font-size: 1.1em; /* Adjust some font sizes */
+  --n8-deep-blue-color: #054C91;
+  --n8-burnt-orange-color: #F95423;
+  --n8-burnt-orange-color-a11y: #D13505;
+  --n8-burnt-orange-lightest-color: #FFF6F5; /* equivalent of burnt orange with alpha 0.05 */
+  --n8-cool-grey-10-color: #63666A;
+  --n8-cool-grey-6-color: #A7A8AA;
+  --n8-cool-grey-5-color: #b1b3b3;
+  --n8-cool-grey-4-color: #bbbcbc;
+  --n8-cool-grey-3-color: #c8c9c7;
+  --n8-cool-grey-2-color: #D0D0CE;
+  --n8-cool-grey-2-lighter-color: #E1E1E0; /* equivalent of Cool grey 2 with alpha 0.5 */
+  --n8-cool-grey-2-lightest-color: #F1F1F0; /* equivalent of Cool grey 2 with alpha 0.3 */
+  --n8-light-theme-background-color: #f5f5f5;
+  --n8-light-theme-text-color: #212529;
+  --n8-light-theme-text-color-muted: #212529;
+  --pygments-default-background-color: #f8f8f8;
 }
 
+/* -----------------------------------------
+  Non-theme specific / universal css changes
+  ------------------------------------------*/
+
+html {
+  --pst-sidebar-font-size: 1.0rem;
+}
+
+/* Change the font family to match the N8 CIR website */
 body {
-  font-family: "Montserrat", "Arial";
-  color: var(--general-text-color);
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
 }
 
-/* Reset the general page background to an off white for reduced brightness */
-body,
-.header-article,
-#site-navigation,
-.headerbtn,
-.bd-toc nav {
-  background: var(--general-background-color);
-}
-
-@media (max-width: 768px) {
-  .bd-toc {
-    background: var(--general-background-color);
-  }
-}
-
-#site-navigation .form-control {
-  background: var(--general-background-color);
-}
-
-#site-navigation nav ul.nav li a, 
-#site-navigation nav ul.nav ul li a {
-  color: var(--general-text-color);
+/* Ensure announcement links are distinguishable from regular text */
+.bd-header-announcement a {
+  font-weight: bold;
+  text-decoration: underline;
 }
 
 /* Reduce padding / increase content width from 768px and above when navigation is hidden */
@@ -58,42 +46,7 @@ body,
   }
 }
 
-/* Change the colour of headings to the N8 blue */
-.content-container h1,
-.content-container h2,
-.content-container h3,
-.content-container h4
-.content-container h5 {
-  color: var(--deep-blue-color);
-}
-
-.bd-toc nav .toc-h2 { 
-  font-size: 1.0em;
-}
-
-code {
-  /* The N8cir orange does not provide enough contrast, so using a darker shade (reduced luminance until > 4.50 contrast ratios */
-  color: var(--burnt-orange-color-a11y);
-}
-
-/* Customise the sphinx-book-theme announcement colour */
-
-.header-item.announcement {
-  background: var(--deep-blue-color);
-}
-
-.header-item.announcement a {
-  color: var(--burnt-orange-color-lightest);
-  font-weight: bold;
-  text-decoration: underline;
-}
-
-/* Hide the prev/next links from sphinx-book-theme */
-.prev-next-area {
-  display: none;
-}
-
-/* Customised version of the search bar with a submit button for accessibility */
+/* Theming for customised Customise version of the search bar which includes a submission button for a11y*/
 .custom-bd-search {
   padding: 1rem 15px 0 15px;
   margin-right: -15px;
@@ -102,13 +55,12 @@ code {
 .custom-bd-search input,
 .custom-bd-search .btn {
   border-radius: 0;
-  border: 1px solid var(--cool-grey-2-lighter-color);
 }
 .custom-bd-search .btn-outline-secondary:hover {
-  background-color: var(--deep-blue-color);
+  background-color: var(--pst-color-primary);
 }
 
-/* Incrase the maximum width for large displays. Still limited to prevent very long line length */
+/* Increase the maximum width for large displays. Still limited to prevent very long line length */
 @media (min-width:1200px) {
   .container,
   .container-lg,
@@ -119,25 +71,9 @@ code {
   }
 }
 
-/* Hide an element visible on mobile that shouldn't be */
-#site-navigation label.d-block.d-md-none.nav-toggle-button.headerbtn {
-  display: none!important; /* Important required due to use of it in the them :cry: */
-}
-
-/* Overwrite padding left for a strongly styled part of the theme */
-.col.pl-md-3.pl-lg-5.content-container {
-  padding-left: 1.5rem !important;
-}
-
-@media (min-width:768px) {
-  #main-content {
-    max-width:74%
-  }
-}
-
 /* Styling tweaks for ethical ads. */
 .ethical-sidebar, .ethical-footer {
-  border: 1px solid var(--cool-grey-2-lighter-color);
+  border: 1px solid var(--n8-cool-grey-2-lighter-color);
   margin-bottom: 2.5rem;
 }
 /* Push down the ethical ads to the bottom of the sidebar, but above the version selector */
@@ -149,3 +85,46 @@ code {
 #ethical-ads-container {
   margin-top:auto;
 }
+
+/* --------------------------------------
+  Light theme specific formatting changes
+  --------------------------------------- */
+html[data-theme="light"] {
+  --pst-color-background: var(--n8-light-background-color);
+  --pst-color-text-base: var(--n8-light-theme-text-color);
+  --pst-color-text-muted: var(--n8-light-theme-text-color-muted);
+  --pst-color-primary: var(--n8-deep-blue-color);
+  --pst-color-secondary: var(--n8-burnt-orange-color-a11y);
+  --pst-color-accent: var(--n8-burnt-orange-color-a11y);
+  --pst-color-inline-code: var(--n8-burnt-orange-color-a11y);
+  --pst-color-link: var(--n8-deep-blue-color);
+  --pst-color-preformatted-background: var(--pygments-default-background-color);
+  --sbt-color-announcement: var(--n8-deep-blue-color);
+}
+/* Override the default sphinx book theme announcement colour */
+html[data-theme="light"] .bd-header-announcement a {
+  color: var(--n8-burnt-orange-color-lightest);
+}
+/* Set light theme colours for custom search form elements */
+html[data-theme="light"] #site-navigation .form-control {
+  background: var(--n8-light-background-color);
+}
+html[data-theme="light"] .custom-bd-search input,
+html[data-theme="light"] .custom-bd-search .btn {
+  border: 1px solid var(--n8-cool-grey-2-lighter-color);
+}
+/* Change the colour of headings to the N8 blue */
+html[data-theme="light"] .bd-article-container h1,
+html[data-theme="light"] .bd-article-container h2,
+html[data-theme="light"] .bd-article-container h3,
+html[data-theme="light"] .bd-article-container h4
+html[data-theme="light"] .bd-article-container h5 {
+  color: var(--n8-deep-blue-color);
+}
+
+/* -------------------------------------
+  Dark theme specific formatting changes
+  -------------------------------------- */
+/* html[data-theme="dark"] {
+
+} */

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -2,6 +2,7 @@
 /* Define N8 theme colours (and lighter versions) */
 :root {
   --n8-deep-blue-color: #054C91;
+  --n8-deep-blue-color-a11y: #0E7CE6; /*n8 deep blue, but scaled to have 4.5 contrast ratio with 111111 */
   --n8-burnt-orange-color: #F95423;
   --n8-burnt-orange-color-a11y: #D13505;
   --n8-burnt-orange-lightest-color: #FFF6F5; /* equivalent of burnt orange with alpha 0.05 */
@@ -17,6 +18,11 @@
   --n8-light-theme-text-color: #212529;
   --n8-light-theme-text-color-muted: #212529;
   --pygments-default-background-color: #f8f8f8;
+
+  --n8-dark-theme-background-color: #111111;
+  --n8-dark-theme-text-color: #F0F6FC;
+  --n8-dark-theme-text-color-muted: #9ca4af;
+  --n8-dark-theme-inline-code-background-color: #1f2733;
 }
 
 /* -----------------------------------------
@@ -125,6 +131,40 @@ html[data-theme="light"] .bd-article-container h5 {
 /* -------------------------------------
   Dark theme specific formatting changes
   -------------------------------------- */
-/* html[data-theme="dark"] {
-
-} */
+html[data-theme="dark"] {
+  --pst-color-background: var(--n8-dark-theme-background-color);
+  --pst-color-text-base: var(--n8-dark-theme-text-color);
+  --pst-color-text-muted: var(--n8-dark-theme-text-color-muted);
+  --pst-color-primary: var(--n8-deep-blue-color-a11y);
+  --pst-color-secondary: var(--n8-burnt-orange-color);
+  --pst-color-accent: var(--n8-burnt-orange-color);
+  --pst-color-surface: var(--n8-dark-theme-inline-code-background-color); /* inline code block background colour */
+  --pst-color-inline-code: var(--n8-burnt-orange-color);
+  --pst-color-link: var(--n8-deep-blue-color-a11y);
+   /* var(--n8-deep-blue-color); */
+  /* --pst-color-preformatted-background: var(--pygments-default-background-color); */
+  --sbt-color-announcement: var(--n8-deep-blue-color);
+}
+/* Override the default sphinx book theme announcement colour */
+html[data-theme="dark"] .bd-header-announcement a {
+  color: var(--n8-burnt-orange-color-lightest);
+}
+/* Set light theme colours for custom search form elements */
+html[data-theme="dark"] #site-navigation .form-control {
+  background: var(--n8-dark-theme-background-color);
+}
+html[data-theme="dark"] .custom-bd-search input,
+html[data-theme="dark"] .custom-bd-search .btn {
+  border: 1px solid var(--n8-cool-grey-2-lighter-color);
+}
+html[data-theme="dark"] .form-control::placeholder {
+  color: var(--pst-color-text-muted);
+}
+/* Change the colour of headings to the N8 blue */
+html[data-theme="dark"] .bd-article-container h1,
+html[data-theme="dark"] .bd-article-container h2,
+html[data-theme="dark"] .bd-article-container h3,
+html[data-theme="dark"] .bd-article-container h4
+html[data-theme="dark"] .bd-article-container h5 {
+  color: var(--n8-deep-blue-color-a11y);
+}

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -90,7 +90,7 @@ body {
   Light theme specific formatting changes
   --------------------------------------- */
 html[data-theme="light"] {
-  --pst-color-background: var(--n8-light-background-color);
+  --pst-color-background: var(--n8-light-theme-background-color);
   --pst-color-text-base: var(--n8-light-theme-text-color);
   --pst-color-text-muted: var(--n8-light-theme-text-color-muted);
   --pst-color-primary: var(--n8-deep-blue-color);
@@ -107,7 +107,7 @@ html[data-theme="light"] .bd-header-announcement a {
 }
 /* Set light theme colours for custom search form elements */
 html[data-theme="light"] #site-navigation .form-control {
-  background: var(--n8-light-background-color);
+  background: var(--n8-light-theme-background-color);
 }
 html[data-theme="light"] .custom-bd-search input,
 html[data-theme="light"] .custom-bd-search .btn {

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -2,9 +2,9 @@
 /* Define N8 theme colours (and lighter versions) */
 :root {
   --n8-deep-blue-color: #054C91;
-  --n8-deep-blue-color-a11y: #0E7CE6; /*n8 deep blue, but scaled to have 4.5 contrast ratio with 111111 */
+  --n8-deep-blue-color-high-contrast-dark: #0E7CE6; /*n8 deep blue, but scaled to have 4.5 contrast ratio with 111111 */
   --n8-burnt-orange-color: #F95423;
-  --n8-burnt-orange-color-a11y: #D13505;
+  --n8-burnt-orange-color-high-contrast-light: #D13505;
   --n8-burnt-orange-lightest-color: #FFF6F5; /* equivalent of burnt orange with alpha 0.05 */
   --n8-cool-grey-10-color: #63666A;
   --n8-cool-grey-6-color: #A7A8AA;
@@ -18,7 +18,6 @@
   --n8-light-theme-text-color: #212529;
   --n8-light-theme-text-color-muted: #212529;
   --pygments-default-background-color: #f8f8f8;
-
   --n8-dark-theme-background-color: #111111;
   --n8-dark-theme-text-color: #F0F6FC;
   --n8-dark-theme-text-color-muted: #9ca4af;
@@ -100,9 +99,9 @@ html[data-theme="light"] {
   --pst-color-text-base: var(--n8-light-theme-text-color);
   --pst-color-text-muted: var(--n8-light-theme-text-color-muted);
   --pst-color-primary: var(--n8-deep-blue-color);
-  --pst-color-secondary: var(--n8-burnt-orange-color-a11y);
-  --pst-color-accent: var(--n8-burnt-orange-color-a11y);
-  --pst-color-inline-code: var(--n8-burnt-orange-color-a11y);
+  --pst-color-secondary: var(--n8-burnt-orange-color-high-contrast-light);
+  --pst-color-accent: var(--n8-burnt-orange-color-high-contrast-light);
+  --pst-color-inline-code: var(--n8-burnt-orange-color-high-contrast-light);
   --pst-color-link: var(--n8-deep-blue-color);
   --pst-color-preformatted-background: var(--pygments-default-background-color);
   --sbt-color-announcement: var(--n8-deep-blue-color);
@@ -135,12 +134,12 @@ html[data-theme="dark"] {
   --pst-color-background: var(--n8-dark-theme-background-color);
   --pst-color-text-base: var(--n8-dark-theme-text-color);
   --pst-color-text-muted: var(--n8-dark-theme-text-color-muted);
-  --pst-color-primary: var(--n8-deep-blue-color-a11y);
+  --pst-color-primary: var(--n8-deep-blue-color-high-contrast-dark);
   --pst-color-secondary: var(--n8-burnt-orange-color);
   --pst-color-accent: var(--n8-burnt-orange-color);
   --pst-color-surface: var(--n8-dark-theme-inline-code-background-color); /* inline code block background colour */
   --pst-color-inline-code: var(--n8-burnt-orange-color);
-  --pst-color-link: var(--n8-deep-blue-color-a11y);
+  --pst-color-link: var(--n8-deep-blue-color-high-contrast-dark);
    /* var(--n8-deep-blue-color); */
   /* --pst-color-preformatted-background: var(--pygments-default-background-color); */
   --sbt-color-announcement: var(--n8-deep-blue-color);
@@ -166,5 +165,5 @@ html[data-theme="dark"] .bd-article-container h2,
 html[data-theme="dark"] .bd-article-container h3,
 html[data-theme="dark"] .bd-article-container h4
 html[data-theme="dark"] .bd-article-container h5 {
-  color: var(--n8-deep-blue-color-a11y);
+  color: var(--n8-deep-blue-color-high-contrast-dark);
 }

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -65,6 +65,7 @@ body {
   background-color: var(--pst-color-primary);
 }
 
+
 /* Increase the maximum width for large displays. Still limited to prevent very long line length */
 @media (min-width:1200px) {
   .container,
@@ -89,6 +90,12 @@ body {
 }
 #ethical-ads-container {
   margin-top:auto;
+}
+
+/* Override theme rule which was causing a scrollbar within the nav bar when not needed on local builds.
+May need adjusting on rtd for ethical ads*/
+.bd-sidebar-primary .sidebar-primary-items__end {
+  margin-top: inherit;
 }
 
 /* --------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -46,10 +46,6 @@ language="en"
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.rst', "common/*.rst", '**.inc.rst', 'venv*', '.venv*']
 
-# The name of the Pygments (syntax highlighting) style to use.
-# The default is one of the few pygments themes with sufficient contrast
-pygments_style = 'default'
-
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
@@ -88,6 +84,10 @@ html_theme_options = {
     "toc_title": "Contents",
     "show_toc_level": 2,
     "show_prev_next": False,
+    # Code highlighting theme for light mode
+    "pygment_light_style": "github-light-high-contrast",
+    # Code highlighting theme for dark mode
+    "pygment_dark_style": "github-dark-high-contrast",
     # Add an announcement bar, visible at the top of each page.
     # "announcement": "",
     # Add the traditional footer theme and sphinx acknowledgements

--- a/conf.py
+++ b/conf.py
@@ -94,6 +94,11 @@ html_theme_options = {
     "extra_footer": f"<p>&nbsp;Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>.</p>"
 }
 
+# Select the default theme automatically. options light/dark/auto
+html_context = {
+    "default_mode": "auto",
+}
+
 html_sidebars = {
     "**": [
         "navbar-logo.html",

--- a/conf.py
+++ b/conf.py
@@ -76,30 +76,26 @@ html_js_files = [
 html_logo = '_static/images/logo-cmyk.png'
 
 html_theme_options = {
-    "single_page": False,
     "repository_url": "https://github.com/N8-CIR-Bede/documentation",
     "use_edit_page_button": False,
     "use_issues_button": True,
     "use_repository_button": True,
     "use_download_button": False,
-    "logo_only": True,
     "use_fullscreen_button": False,
     "home_page_in_toc": True,
     "show_navbar_depth": 1,  # Sets the depth for expanded content
     # Control the right hand in-page toc
     "toc_title": "Contents",
     "show_toc_level": 2,
-    # Reset the navigation bar footer (html)
-    "extra_navbar": "",
     # Add an announcement bar, visible at the top of each page.
     # "announcement": "",
     # Add the traditional footer theme and sphinx acknowledgements
-    "extra_footer": f"Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>."
+    "extra_footer": f"<p>Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>.</p>"
 }
 
 html_sidebars = {
     "**": [
-        "sidebar-logo.html",
+        "navbar-logo.html",
         "a11y-search-field.html",
         "sbt-sidebar-nav.html",
         "ethical-ads.html"

--- a/conf.py
+++ b/conf.py
@@ -82,7 +82,7 @@ html_theme_options = {
     "use_repository_button": True,
     "use_download_button": False,
     "use_fullscreen_button": False,
-    "home_page_in_toc": True,
+    "home_page_in_toc": False,
     "show_navbar_depth": 1,  # Sets the depth for expanded content
     # Control the right hand in-page toc
     "toc_title": "Contents",

--- a/conf.py
+++ b/conf.py
@@ -87,10 +87,11 @@ html_theme_options = {
     # Control the right hand in-page toc
     "toc_title": "Contents",
     "show_toc_level": 2,
+    "show_prev_next": False,
     # Add an announcement bar, visible at the top of each page.
     # "announcement": "",
     # Add the traditional footer theme and sphinx acknowledgements
-    "extra_footer": f"<p>Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>.</p>"
+    "extra_footer": f"<p>&nbsp;Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>.</p>"
 }
 
 html_sidebars = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,5 @@
-sphinx==4.3.1
-sphinxcontrib-applehelp==1.0.1
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.1
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.5
-sphinx-book-theme==0.3.2
+sphinx>=7.0.0,<8.0.0
+sphinx-book-theme==1.1.2
 sphinx-autobuild
 sphinxext-rediraffe
 sphinx-copybutton


### PR DESCRIPTION
Updates sphinx and sphinx-book theme python dependencies to current versions.

Due to breaking changes in the theme, conf.py and custom.css changes were required. 
This also allowed some previous theme workarounds to be removed.

Closes #184

## Todo

+ [x] Update sphinx and theme python requirements
+ [x] Bump python version in readme and ci. >= 3.9 required due to theme. 3.12 in use on CI/RTD.
+ [x] Customise light theme styling to match previous documentation theme
+ [x] Customise dark theme with N8 branding
+ [x] Run a11y checks on light theme
   + Only pa11y reports on the few pages i've tried have been search input fields for a duplicate form from the theme which is not visible
+ [x] Run a11y checks on dark theme.