### PR TITLE
Grace-Hopper non-pilot documentation

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -120,6 +120,7 @@ html[data-theme="light"] {
   --pst-color-text-muted: var(--n8-light-theme-text-color-muted);
   --pst-color-primary: var(--n8-deep-blue-color);
   --pst-color-secondary: var(--n8-burnt-orange-color-high-contrast-light);
+  --pst-color-warning: var(--n8-burnt-orange-color-high-contrast-light);
   --pst-color-accent: var(--n8-burnt-orange-color-high-contrast-light);
   --pst-color-inline-code: var(--n8-burnt-orange-color-high-contrast-light);
   --pst-color-link: var(--n8-deep-blue-color);
@@ -170,6 +171,7 @@ html[data-theme="dark"] {
   --pst-color-text-muted: var(--n8-dark-theme-text-color-muted);
   --pst-color-primary: var(--n8-deep-blue-color-high-contrast-dark);
   --pst-color-secondary: var(--n8-burnt-orange-color);
+  --pst-color-warning: var(--n8-burnt-orange-color);
   --pst-color-accent: var(--n8-burnt-orange-color);
   --pst-color-surface: var(--n8-dark-theme-inline-code-background-color); /* inline code block background colour */
   --pst-color-inline-code: var(--n8-burnt-orange-color);

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -30,7 +30,6 @@
 /* -----------------------------------------
   Non-theme specific / universal css changes
   ------------------------------------------*/
-
 html {
   --pst-sidebar-font-size: 1.0rem;
 }
@@ -110,6 +109,13 @@ html .sphinx-tabs-panel {
 html [role="tablist"] {
   border-bottom-color: var(--sphinx-tabs-border-color);
 }
+html .sphinx-tabs-panel pre {
+  background-color: var(--color-surface-tabs);
+}
+/* Fix right border of selected tab from being hidden */
+.sphinx-tabs-tab[aria-selected="true"] {
+  z-index: 2;
+}
 
 /* --------------------------------------
   Light theme specific formatting changes
@@ -126,6 +132,7 @@ html[data-theme="light"] {
   --pst-color-link: var(--n8-deep-blue-color);
   --pst-color-preformatted-background: var(--pygments-default-background-color);
   --sbt-color-announcement: var(--n8-deep-blue-color);
+  --color-surface-tabs: #fcfcfc;
 }
 /* Override the default sphinx book theme announcement colour */
 html[data-theme="light"] .bd-header-announcement a {
@@ -176,12 +183,7 @@ html[data-theme="dark"] {
   --pst-color-surface: var(--n8-dark-theme-inline-code-background-color); /* inline code block background colour */
   --pst-color-inline-code: var(--n8-burnt-orange-color);
   --pst-color-link: var(--n8-deep-blue-color-high-contrast-dark);
-   /* var(--n8-deep-blue-color); */
-  /* --pst-color-preformatted-background: var(--pygments-default-background-color); */
-  /* --sbt-color-announcement: var(--n8-deep-blue-color);
-  --sphinx-tabs-tab-color: #f00;
-  --sphinx-tabs-background-color: #ff0;
-  --sphinx-tabs-border-color: #00f; */
+  --color-surface-tabs: #181e27;
 }
 /* Override the default sphinx book theme announcement colour */
 html[data-theme="dark"] .bd-header-announcement a {

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -22,6 +22,9 @@
   --n8-dark-theme-text-color: #F0F6FC;
   --n8-dark-theme-text-color-muted: #9ca4af;
   --n8-dark-theme-inline-code-background-color: #1f2733;
+  --sphinx-tabs-tab-color: var(--pst-color-primary);
+  --sphinx-tabs-background-color: var(--pst-color-surface);
+  --sphinx-tabs-border-color: var(--pst-color-primary);
 }
 
 /* -----------------------------------------
@@ -90,6 +93,23 @@ body {
     max-width:1600px
   }
 }
+/* Sphinx tabs theming via variables for easier light/dark theming */
+html .sphinx-tabs-tab {
+  color: var(--sphinx-tabs-tab-color);
+  background-color: var(--sphinx-tabs-background-color);
+}
+html .sphinx-tabs-tab[aria-selected="true"] {
+  border-color: var(--sphinx-tabs-border-color);
+  border-bottom-color: var(--sphinx-tabs-background-color);
+  background: var(--sphinx-tabs-background-color);
+}
+html .sphinx-tabs-panel {
+  background: var(--sphinx-tabs-background-color);
+  border-color: var(--sphinx-tabs-border-color);
+}
+html [role="tablist"] {
+  border-bottom-color: var(--sphinx-tabs-border-color);
+}
 
 /* --------------------------------------
   Light theme specific formatting changes
@@ -126,6 +146,20 @@ html[data-theme="light"] .bd-article-container h4
 html[data-theme="light"] .bd-article-container h5 {
   color: var(--n8-deep-blue-color);
 }
+/* Sphinx-tabs light/dark themed styling tweaks */ 
+/* html[data-theme="light"] .sphinx-tabs-tab {
+  color: var(--pst-color-primary);
+  background-color: #0f0;
+}
+html[data-theme="light"] .sphinx-tabs-tab[aria-selected="true"] {
+  border-color: #ff0;
+  border-bottom-color: #00F;
+  background: #00f;
+}
+html[data-theme="light"] .sphinx-tabs-panel {
+  background: #00cccc;
+} */
+
 
 /* -------------------------------------
   Dark theme specific formatting changes
@@ -142,7 +176,10 @@ html[data-theme="dark"] {
   --pst-color-link: var(--n8-deep-blue-color-high-contrast-dark);
    /* var(--n8-deep-blue-color); */
   /* --pst-color-preformatted-background: var(--pygments-default-background-color); */
-  --sbt-color-announcement: var(--n8-deep-blue-color);
+  /* --sbt-color-announcement: var(--n8-deep-blue-color);
+  --sphinx-tabs-tab-color: #f00;
+  --sphinx-tabs-background-color: #ff0;
+  --sphinx-tabs-border-color: #00f; */
 }
 /* Override the default sphinx book theme announcement colour */
 html[data-theme="dark"] .bd-header-announcement a {

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -4,10 +4,12 @@ so cannot use sphinx :ref: for output destination URIs relative to the current p
 Instead, find the appropriate link within the current page, to add the anchor to the announcement.
 This does not currently support linking outside of the documentation website.
 */
-/* window.onload = function () {
-    expectedAnnouncementContent = "";
-    expectedAnchorContent = "";
-    var elements = document.getElementsByClassName("announcement");
+ window.onload = function () {
+    expectedAnnouncementContent = "Using Bede";
+    expectedAnchorContent = "Using Bede";
+    optionalTargetID = "grace-hopper-pilot"; // null if linking to page
+    fullAnnouncementAnchor = false;
+    var elements = document.getElementsByClassName("bd-header-announcement");
     for (var i = 0; i < elements.length; i++) {
         var element = elements.item(i);
         originalContent = element.innerHTML;
@@ -28,10 +30,16 @@ This does not currently support linking outside of the documentation website.
                         // then append the optionalTargetID, which should no longer begin with a hash.
                         targetDestination += optionalTargetID;
                     }
-                    newAnnouncementContent = '<a href="' + targetDestination + '">' + originalContent + '</a>'
-                    element.innerHTML = newAnnouncementContent;
+                    // Either wrap the full announcement body in the anchor, or just the expected anchor content
+                    if (fullAnnouncementAnchor) {
+                        newAnnouncementContent = '<a href="' + targetDestination + '">' + originalContent + '</a>'
+                        element.innerHTML = newAnnouncementContent;
+                    } else {
+                        newAnnouncementContent = originalContent.replace(expectedAnchorContent, '<a href="' + targetDestination + '">' + expectedAnchorContent + '</a>')
+                        element.innerHTML = newAnnouncementContent;
+                    }
                 }
             }
         }
     }
-} */
+}

--- a/common/aarch64-only-sidebar.rst
+++ b/common/aarch64-only-sidebar.rst
@@ -1,4 +1,4 @@
 .. admonition:: aarch64 partitions only
-    :class: warning
+    :class: sidebar warning
 
     |arch_availabilty_name| is only provided on ``aarch64`` partitions (``gh``, ``ghtest``, ``ghlogin``).

--- a/common/aarch64-only.rst
+++ b/common/aarch64-only.rst
@@ -1,0 +1,4 @@
+.. admonition:: aarch64 partitions only
+    :class: sidebar warning
+
+    |arch_availabilty_name| is only provided on ``aarch64`` partitions (``gh``, ``ghtest``, ``ghlogin``).

--- a/common/ppc64le-only-sidebar.rst
+++ b/common/ppc64le-only-sidebar.rst
@@ -1,4 +1,4 @@
 .. admonition:: ppc64le partitions only
-    :class: warning
+    :class: sidebar warning
 
     |arch_availabilty_name| is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).

--- a/common/ppc64le-only.rst
+++ b/common/ppc64le-only.rst
@@ -1,0 +1,4 @@
+.. admonition:: ppc64le partitions only
+    :class: sidebar warning
+
+    |arch_availabilty_name| is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).

--- a/conf.py
+++ b/conf.py
@@ -94,7 +94,7 @@ html_theme_options = {
     # Code highlighting theme for dark mode
     "pygment_dark_style": "github-dark-high-contrast",
     # Add an announcement bar, visible at the top of each page.
-    "announcement": "3 NVIDIA Grace-Hopper nodes (GH200 480) are now available",
+    "announcement": "3 NVIDIA Grace-Hopper nodes (GH200 480) are now available. See Using Bede for more information.",
     # Add the traditional footer theme and sphinx acknowledgements
     "extra_footer": f"<p>&nbsp;Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>.</p>"
 }

--- a/conf.py
+++ b/conf.py
@@ -94,7 +94,7 @@ html_theme_options = {
     # Code highlighting theme for dark mode
     "pygment_dark_style": "github-dark-high-contrast",
     # Add an announcement bar, visible at the top of each page.
-    "announcement": "",
+    "announcement": "3 NVIDIA Grace-Hopper nodes (GH200 480) are now available",
     # Add the traditional footer theme and sphinx acknowledgements
     "extra_footer": f"<p>&nbsp;Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>.</p>"
 }

--- a/conf.py
+++ b/conf.py
@@ -11,7 +11,8 @@ import sphinx
 extensions = [
     "sphinxext.rediraffe",
     'sphinx.ext.mathjax',
-    'sphinx_copybutton'
+    'sphinx_copybutton',
+    'sphinx_tabs.tabs',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/conf.py
+++ b/conf.py
@@ -53,6 +53,9 @@ todo_include_todos = False
 ## Added by CA to get MathJax rendering loaded
 mathjax_path='https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'
 
+# Disable sphinx-tabs closing
+sphinx_tabs_disable_tab_closing = True
+
 # -- Options for HTML output ----------------------------------------------
 
 html_theme = 'sphinx_book_theme'
@@ -82,6 +85,7 @@ html_theme_options = {
     "home_page_in_toc": False,
     "show_navbar_depth": 1,  # Sets the depth for expanded content
     # Control the right hand in-page toc
+    "navigation_with_keys": False,
     "toc_title": "Contents",
     "show_toc_level": 2,
     "show_prev_next": False,

--- a/faq/index.rst
+++ b/faq/index.rst
@@ -137,3 +137,26 @@ find the support email address for your institution `on the N8CIR website
 There is also a `slack workspace <https://n8cirbede.slack.com>`__ that you can join to get further support and
 contact the Bede user community. To request access, please e-mail: marion.weinzierl@durham.ac.uk.
 
+.. _faq-architecture-specific-eng:
+
+How do I specialise my bash environment for Power 9 and Grace-Hopper systems?
+-----------------------------------------------------------------------------
+
+If you have modified your Bede user environment (``.bashrc``, or ``.bash_profile``) to make software available by default (i.e. conda),
+you may need to modify your environment to set environment variables or source scripts based on the CPU architecture.
+
+You can check the CPU architecture in bash using the ``uname`` command.
+
+This allows you to set different environment variables on the ``aarch64`` Grace-Hopper nodes than on the ``ppc64le`` Power 9 nodes:
+
+.. code-block:: bash
+
+   # Get the CPU architecture
+   arch=$(uname -i)
+   if [[ $arch == "aarch64" ]]; then
+      # Set variables and source scripts for aarch64
+       export MYVAR=FOO
+   elif [[ $arch == "ppc64le" ]]; then
+      # Set variables and source scripts for ppc64le
+       export MYVAR=BAR
+   fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx-book-theme==1.1.2
 sphinx-autobuild
 sphinxext-rediraffe
 sphinx-copybutton
+sphinx-tabs==3.4.5

--- a/software/applications/amber.rst
+++ b/software/applications/amber.rst
@@ -1,7 +1,10 @@
 .. _software-applications-amber:
 
 AMBER
--------
+-----
+
+.. |arch_availabilty_name| replace:: AMBER
+.. include:: /common/ppc64le-only.rst
 
 `AMBER <https://ambermd.org/>`__ is a suite of biomolecular simulation programs. It began in the late 1970's, and is maintained by an active development community.
 

--- a/software/applications/amber.rst
+++ b/software/applications/amber.rst
@@ -4,7 +4,7 @@ AMBER
 -----
 
 .. |arch_availabilty_name| replace:: AMBER
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 `AMBER <https://ambermd.org/>`__ is a suite of biomolecular simulation programs. It began in the late 1970's, and is maintained by an active development community.
 

--- a/software/applications/conda.rst
+++ b/software/applications/conda.rst
@@ -15,29 +15,61 @@ The simplest way to install Conda for use on Bede is through the `miniconda <htt
 
 .. note::
 
-    You may wish to install conda into the ``/nobackup/projects/<project>/$USER`` (where ``project`` is the project code for your project) directory rather than your ``home`` directory as it may consume considerable disk space
+    You may wish to install conda into the ``/nobackup/projects/<project>/$USER/<architecture>`` (where ``<project>`` is the project code for your project, and ``<architecture>>`` is CPU architecture) directory rather than your ``home`` directory as it may consume considerable disk space
 
-.. code-block:: bash
+.. tabs::
 
-   export CONDADIR=/nobackup/projects/<project>/$USER # Update this with your <project> code.
-   mkdir -p $CONDADIR
-   pushd $CONDADIR
+   .. code-tab:: bash ppc64le
 
-   # Download the latest miniconda installer for ppcle64
-   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh
-   # Validate the file checksum matches is listed on https://docs.conda.io/en/latest/miniconda_hashes.html.
-   sha256sum Miniconda3-latest-Linux-ppc64le.sh
+      export CONDADIR=/nobackup/projects/<project>/$USER/ppc64le # Update this with your <project> code.
+      mkdir -p $CONDADIR
+      pushd $CONDADIR
 
-   sh Miniconda3-latest-Linux-ppc64le.sh -b -p ./miniconda
-   source miniconda/etc/profile.d/conda.sh
-   conda update conda -y
+      # Download the latest miniconda installer for ppc64le
+      wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-ppc64le.sh
+      # Validate the file checksum matches is listed on https://docs.conda.io/en/latest/miniconda_hashes.html.
+      sha256sum Miniconda3-latest-Linux-ppc64le.sh
+
+      sh Miniconda3-latest-Linux-ppc64le.sh -b -p ./miniconda
+      source miniconda/etc/profile.d/conda.sh
+      conda update conda -y
+   
+   .. code-tab:: bash aarch64
+
+      export CONDADIR=/nobackup/projects/<project>/$USER/aarch64 # Update this with your <project> code.
+      mkdir -p $CONDADIR
+      pushd $CONDADIR
+
+      # Download the latest miniconda installer for aarch64
+      wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh
+      # Validate the file checksum matches is listed on https://docs.conda.io/en/latest/miniconda_hashes.html.
+      sha256sum Miniconda3-latest-Linux-aarch64.sh
+
+      sh Miniconda3-latest-Linux-aarch64.sh -b -p ./miniconda
+      source miniconda/etc/profile.d/conda.sh
+      conda update conda -y
 
 On subsequent sessions, or in job scripts you may need to re-source miniconda. Alternatively you could add this to your bash environment. I.e. 
 
-.. code-block:: bash
+.. tabs::
 
-    export CONDADIR=/nobackup/projects/<project>/$USER # Update this with your <project> code.
-    source $CONDADIR/miniconda/etc/profile.d/conda.sh
+   .. code-tab:: bash ppc64le
+
+      arch=$(uname -i) # Get the CPU architecture
+      if [[ $arch == "ppc64le" ]]; then
+         # Set variables and source scripts for ppc64le
+         export CONDADIR=/nobackup/projects/<project>/$USER/ppc64le # Update this with your <project> code.
+         source $CONDADIR/miniconda/etc/profile.d/conda.sh
+      fi
+
+   .. code-tab:: bash aarch64
+      
+      arch=$(uname -i) # Get the CPU architecture
+      if [[ $arch == "aarch64" ]]; then
+         # Set variables and source scripts for aarch64
+         export CONDADIR=/nobackup/projects/<project>/$USER/aarch64 # Update this with your <project> code.
+         source $CONDADIR/miniconda/etc/profile.d/conda.sh
+      fi
 
 Creating a new Conda Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -58,17 +90,17 @@ Once created, the environment can be activated using ``conda activate``.
 
 Alternatively, Conda environments can be created outside of the conda/miniconda install, using the ``-p`` / ``--prefix`` option of ``conda create``. 
 
-I.e. if you have installed miniconda to your home directory, but wish to create a conda environment within the ``/project/<PROJECT>/$USER/`` directory named ``example`` you can use:
+I.e. if you have installed miniconda to your home directory, but wish to create a conda environment within the ``/project/<PROJECT>/$USER/<architecture>/`` directory named ``example`` you can use:
 
 .. code-block:: bash
 
-   conda create -y --prefix /project/<PROJECT>/$USER/example python=3.9
+   conda create -y --prefix /project/<PROJECT>/$USER/<architecture>/example python=3.9
 
 This can subsequently be loaded via:
 
 .. code-block:: bash
 
-   conda activate /project/<PROJECT>/$USER/example
+   conda activate /project/<PROJECT>/$USER/<architecture>/example
 
 Listing and Activating existing Conda Environments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/software/applications/eman2.rst
+++ b/software/applications/eman2.rst
@@ -3,6 +3,9 @@
 EMAN2
 =====
 
+.. |arch_availabilty_name| replace:: EMAN2
+.. include:: /common/ppc64le-only.rst
+
 `EMAN2 <https://blake.bcm.edu/emanwiki/EMAN2>`__ is a broadly based greyscale scientific image processing suite with a primary focus on processing data from transmission electron microscopes.
 
 On Bede, EMAN2 is provided by the :ref:`IBM Collaboration project <software-projects-ibm-collaboration>`.

--- a/software/applications/eman2.rst
+++ b/software/applications/eman2.rst
@@ -4,7 +4,7 @@ EMAN2
 =====
 
 .. |arch_availabilty_name| replace:: EMAN2
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 `EMAN2 <https://blake.bcm.edu/emanwiki/EMAN2>`__ is a broadly based greyscale scientific image processing suite with a primary focus on processing data from transmission electron microscopes.
 

--- a/software/applications/grace.rst
+++ b/software/applications/grace.rst
@@ -3,6 +3,9 @@
 Grace
 -----
 
+.. |arch_availabilty_name| replace:: Grace
+.. include:: /common/ppc64le-only.rst
+
 `Grace <https://plasma-gate.weizmann.ac.il/Grace/>`__ Grace is a WYSIWYG 2D plotting tool for the X Window System.
 
 On Bede, the batch-printing component of Grace, ``gracebat`` is provided via an environment module:

--- a/software/applications/grace.rst
+++ b/software/applications/grace.rst
@@ -4,7 +4,7 @@ Grace
 -----
 
 .. |arch_availabilty_name| replace:: Grace
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 `Grace <https://plasma-gate.weizmann.ac.il/Grace/>`__ Grace is a WYSIWYG 2D plotting tool for the X Window System.
 

--- a/software/applications/gromacs.rst
+++ b/software/applications/gromacs.rst
@@ -3,6 +3,9 @@
 GROMACS
 -------
 
+.. |arch_availabilty_name| replace:: GROMACS
+.. include:: /common/ppc64le-only.rst
+
 `GROMACS <http://www.gromacs.org/About_Gromacs>`__ is a versatile package for molecular dynamics simulation.
 It is primarily designed for biochemical molecules like proteins, lipids and nucleic acids that have a lot of complicated bonded interactions, but since GROMACS is extremely fast at calculating the nonbonded interactions (that usually dominate simulations) many groups are also using it for research on non-biological systems, e.g. polymers.
 

--- a/software/applications/gromacs.rst
+++ b/software/applications/gromacs.rst
@@ -4,7 +4,7 @@ GROMACS
 -------
 
 .. |arch_availabilty_name| replace:: GROMACS
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 `GROMACS <http://www.gromacs.org/About_Gromacs>`__ is a versatile package for molecular dynamics simulation.
 It is primarily designed for biochemical molecules like proteins, lipids and nucleic acids that have a lot of complicated bonded interactions, but since GROMACS is extremely fast at calculating the nonbonded interactions (that usually dominate simulations) many groups are also using it for research on non-biological systems, e.g. polymers.

--- a/software/applications/index.rst
+++ b/software/applications/index.rst
@@ -9,6 +9,18 @@ If you notice any omissions, errors or have any suggested changes to the documen
 
 .. toctree::
     :maxdepth: 1
-    :glob:
 
-    *
+    amber.rst
+    conda.rst
+    eman2.rst
+    grace.rst
+    gromacs.rst
+    namd.rst
+    open-ce.rst
+    openmm.rst
+    python.rst
+    pytorch.rst
+    r.rst
+    rust.rst
+    tensorflow.rst
+    

--- a/software/applications/namd.rst
+++ b/software/applications/namd.rst
@@ -3,6 +3,9 @@
 NAMD
 ----
 
+.. |arch_availabilty_name| replace:: NAMD
+.. include:: /common/ppc64le-only.rst
+
 `NAMD <https://www.ks.uiuc.edu/Research/namd/>`__ is a parallel molecular dynamics code designed for high-performance simulation of large biomolecular systems.
 Based on Charm++ parallel objects, NAMD scales to hundreds of cores for typical simulations and beyond 500,000 cores for the largest simulations.
 

--- a/software/applications/namd.rst
+++ b/software/applications/namd.rst
@@ -4,7 +4,7 @@ NAMD
 ----
 
 .. |arch_availabilty_name| replace:: NAMD
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 `NAMD <https://www.ks.uiuc.edu/Research/namd/>`__ is a parallel molecular dynamics code designed for high-performance simulation of large biomolecular systems.
 Based on Charm++ parallel objects, NAMD scales to hundreds of cores for typical simulations and beyond 500,000 cores for the largest simulations.

--- a/software/applications/open-ce.rst
+++ b/software/applications/open-ce.rst
@@ -3,6 +3,9 @@
 Open-CE
 =======
 
+.. |arch_availabilty_name| replace:: Open-CE
+.. include:: /common/ppc64le-only.rst
+
 The `Open Cognitive Environment (Open-CE) <https://osuosl.org/services/powerdev/opence/>`__ is a community driven software distribution for machine learning and deep learning frameworks.
 
 Open-CE software is distributed via :ref:`Conda<software-applications-conda>`, with all included packages for a given Open-CE release being installable in to the same conda environment.

--- a/software/applications/open-ce.rst
+++ b/software/applications/open-ce.rst
@@ -4,7 +4,7 @@ Open-CE
 =======
 
 .. |arch_availabilty_name| replace:: Open-CE
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 The `Open Cognitive Environment (Open-CE) <https://osuosl.org/services/powerdev/opence/>`__ is a community driven software distribution for machine learning and deep learning frameworks.
 

--- a/software/applications/openmm.rst
+++ b/software/applications/openmm.rst
@@ -3,6 +3,9 @@
 OpenMM
 ------
 
+.. |arch_availabilty_name| replace:: OpenMM
+.. include:: /common/ppc64le-only.rst
+
 `OpenMM <https://openmm.org/>`__ is a high-performance toolkit for molecular simulation. 
 It can be used as an application, a library, or a flexible programming environment
 and includes extensive language bindings for Python, C, C++, and even Fortran.

--- a/software/applications/openmm.rst
+++ b/software/applications/openmm.rst
@@ -4,7 +4,7 @@ OpenMM
 ------
 
 .. |arch_availabilty_name| replace:: OpenMM
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 `OpenMM <https://openmm.org/>`__ is a high-performance toolkit for molecular simulation. 
 It can be used as an application, a library, or a flexible programming environment

--- a/software/applications/python.rst
+++ b/software/applications/python.rst
@@ -7,7 +7,7 @@ Python
 
 .. tabs::
 
-   .. tab:: ppc64le 
+   .. group-tab:: ppc64le 
 
          Python ``3.6`` is available by default, as ``python3``, however, consider using :ref:`Conda <software-applications-conda>` for your python dependency management.
 
@@ -16,7 +16,7 @@ Python
          On the ``ppc64le`` nodes/partitions  Python 2 is also available, but is no longer an officially supported version of python. 
          If you are still using python 2, upgrade to python 3 as soon as possible.
 
-   .. tab:: aarch64
+   .. group-tab:: aarch64
 
       Python ``3.9`` is available by default on ``aarch64`` nodes, as ``python3`` and ``python``.
       Alternate versions of Python can be installed via :ref:`Conda <software-applications-conda>` 

--- a/software/applications/python.rst
+++ b/software/applications/python.rst
@@ -5,16 +5,28 @@ Python
 
 `Python <https://www.python.org/>`__ is an interpreted, interactive, object-oriented programming language with dynamic typing.
 
-Python 3.6 is available by default on Bede, as ``python3``, however, consider using :ref:`Conda <software-applications-conda>` for your python dependency management.
+.. tabs::
 
-Conda is a cross-platform package and environment management system, which can provide alternate python versions than distributed centrally, and is more-suitable for managing packages which include non-python dependencies. 
+   .. tab:: ppc64le 
 
-Python 2 is also available, but is no longer an officially supported version of python. 
-If you are still using python 2, upgrade to python 3 as soon as possible.
+         Python ``3.6`` is available by default, as ``python3``, however, consider using :ref:`Conda <software-applications-conda>` for your python dependency management.
 
+         Conda is a cross-platform package and environment management system, which can provide alternate python versions than distributed centrally, and is more-suitable for managing packages which include non-python dependencies. 
+
+         On the ``ppc64le`` nodes/partitions  Python 2 is also available, but is no longer an officially supported version of python. 
+         If you are still using python 2, upgrade to python 3 as soon as possible.
+
+   .. tab:: aarch64
+
+      Python ``3.9`` is available by default on ``aarch64`` nodes, as ``python3`` and ``python``.
+      Alternate versions of Python can be installed via :ref:`Conda <software-applications-conda>` 
+
+      Conda is a cross-platform package and environment management system, which can provide alternate python versions than distributed centrally, and is more-suitable for managing packages which include non-python dependencies. 
+
+      Python 2 is not available on the ``aarch64`` nodes/partitions in Bede.
+ 
 If you wish to use non-conda python, you should use `virtual environments <https://docs.python.org/3/library/venv.html>`__ to isolate your python environment(s) from the system-wide environment.
 This will allow you to install your own python dependencies via pip.
-
 
 For instance, to create and install `sphinx` (the python package used to create this documentation) into a python environment in your home directory:
 
@@ -31,7 +43,7 @@ For instance, to create and install `sphinx` (the python package used to create 
    # Use pip to install sphinx into the environment
    python3 -m pip install sphinx
 
-.. note::
+.. warning::
   
    Python virtual environments can become large if large python packages such as TensorFlow are installed. 
    Consider placing your python virtual environments in your project directories to avoid filling your home directory.
@@ -51,5 +63,7 @@ I.e. to delete a python virtual environment located at ``~/.venvs/sphinx``
 
     rm -r ~/.venvs/sphinx/
 
+
+Python packages may install architecture dependent binaries, so you should use a separate virtual environments for ``ppc64le`` and ``aarch64`` nodes/partitions.
 
 For further information on please see the `Python Online Documentation <https://docs.python.org/3/index.html>`__.

--- a/software/applications/pytorch.rst
+++ b/software/applications/pytorch.rst
@@ -6,57 +6,149 @@ PyTorch
 `PyTorch <https://pytorch.org/>`__ is an end-to-end machine learning framework.
 PyTorch enables fast, flexible experimentation and efficient production through a user-friendly front-end, distributed training, and ecosystem of tools and libraries.
 
-The main method of distribution for PyTorch is via :ref:`Conda <software-applications-conda>`, with :ref:`Open-CE<software-applications-open-ce>` providing a simple method for installing multiple machine learning frameworks into a single conda environment.
+The main method of distribution for PyTorch for ``ppc64le`` is via :ref:`Conda <software-applications-conda>`, with :ref:`Open-CE<software-applications-open-ce>` providing a simple method for installing multiple machine learning frameworks into a single conda environment.
 
 The upstream Conda and pip distributions do not provide ppc64le pytorch packages at this time. 
 
 Installing via Conda
 ~~~~~~~~~~~~~~~~~~~~
 
-With a working Conda installation (see :ref:`Installing Miniconda<software-applications-conda-installing>`) the following instructions can be used to create a Python 3.9 conda environment named ``torch`` with the latest Open-CE provided PyTorch:
+.. tabs::
 
-.. note:: 
+   .. group-tab:: ppc64le
 
-   Pytorch installations via conda can be relatively large. Consider installing your miniconda (and therfore your conda environments) to the ``/nobackup`` file store.
+      With a working Conda installation (see :ref:`Installing Miniconda<software-applications-conda-installing>`) the following instructions can be used to create a Python 3.9 conda environment named ``torch`` with the latest Open-CE provided PyTorch:
 
+      .. note:: 
 
-.. code-block:: bash
-
-   # Create a new conda environment named torch within your conda installation
-   conda create -y --name torch python=3.9
-
-   # Activate the conda environment
-   conda activate torch
-
-   # Add the OSU Open-CE conda channel to the current environment config
-   conda config --env --prepend channels https://ftp.osuosl.org/pub/open-ce/current/
-
-   # Also use strict channel priority
-   conda config --env --set channel_priority strict
-
-   # Install the latest available version of PyTorch
-   conda install -y pytorch
-
-In subsequent interactive sessions, and when submitting batch jobs which use PyTorch, you will then need to re-activate the conda environment.
-
-For example, to verify that PyTorch is available and print the version:
-
-.. code-block:: bash
-
-   # Activate the conda environment
-   conda activate torch
-
-   # Invoke python
-   python3 -c "import torch;print(torch.__version__)"
+         Pytorch installations via conda can be relatively large. Consider installing your miniconda (and therfore your conda environments) to the ``/nobackup`` file store.
 
 
-Installation via the upstream Conda channel is not currently possible, due to the lack of ``ppc64le`` or ``noarch`` distributions.
+      .. code-block:: bash
+
+         # Create a new conda environment named torch within your conda installation
+         conda create -y --name torch python=3.9
+
+         # Activate the conda environment
+         conda activate torch
+
+         # Add the OSU Open-CE conda channel to the current environment config
+         conda config --env --prepend channels https://ftp.osuosl.org/pub/open-ce/current/
+
+         # Also use strict channel priority
+         conda config --env --set channel_priority strict
+
+         # Install the latest available version of PyTorch
+         conda install -y pytorch
+
+      In subsequent interactive sessions, and when submitting batch jobs which use PyTorch, you will then need to re-activate the conda environment.
+
+      For example, to verify that PyTorch is available and print the version:
+
+      .. code-block:: bash
+
+         # Activate the conda environment
+         conda activate torch
+
+         # Invoke python
+         python3 -c "import torch;print(torch.__version__)"
 
 
-.. note::
-   
-   The :ref:`Open-CE<software-applications-open-ce>` distribution of PyTorch does not include IBM technologies such as DDL or LMS, which were previously available via :ref:`WMLCE<software-applications-wmlce>`. 
-   WMLCE is no longer supported.
+      Installation via the upstream Conda channel is not currently possible, due to the lack of ``ppc64le`` or ``noarch`` distributions.
+
+
+      .. note::
+         
+         The :ref:`Open-CE<software-applications-open-ce>` distribution of PyTorch does not include IBM technologies such as DDL or LMS, which were previously available via :ref:`WMLCE<software-applications-wmlce>`. 
+         WMLCE is no longer supported.
+
+
+   .. group-tab:: aarch64
+
+      .. warning::
+
+         Conda builds of PyTorch for ``aarch64`` do not include CUDA support as of April 2024. For now, see :ref:`software-applications-pytorch-ngc` or `build from source <https://pytorch.org/get-started/locally/#linux-from-source>`__.
+         
+.. _software-applications-pytorch-ngc:
+
+Using NGC PyTorch Containers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+   .. group-tab:: ppc64le
+
+      .. warning::
+
+         NVIDIA do not provide ``ppc64le`` containers for pytorch through NGC. This method should only be used for ``aarch64`` partitions.
+
+   .. group-tab:: aarch64
+
+      NVIDIA provide docker containers with CUDA-enabled pytorch builds for ``x86_64`` and ``aarch64`` architectures through NGC.
+
+      The `NGC PyTorch <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch>`__ containers have included Hopper support since ``22.09``.
+
+      * ``22.09`` and ``22.10`` provide a conda-based install of pytorch.
+      * ``22.11+`` provide a pip-based install in the default python environment.
+
+      For details of which pytorch version is provided by the each container release, see the `NGC PyTorch container release notes <https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes>`__.
+
+      :ref:`software-tools-apptainer` can be used to convert and run docker containers, or to build an apptainer container based on a docker container. 
+      These can be built on the ``aarch64`` nodes in Bede using :ref:`software-tools-apptainer-rootless`.
+
+      .. note::
+
+         PyTorch containers can consume a large amount of disk space. Consider setting :ref:`software-tools-apptainer-cachedir` to an appropriate location in ``/nobackup``, e.g. ``export APPTAINER_CACHEDIR=/nobackup/projects/${SLURM_JOB_ACCOUNT}/${USER}/apptainer-cache``.
+
+      .. note::
+
+         The following apptainer commands should be executed from an ``aarch64`` node only, i.e. on ``ghlogin``, ``gh`` or ``ghtest``.
+
+      Docker containers can be fetched and converted using ``apptainer pull``, prior to using ``apptainer exec`` to execute code within the container.
+
+      .. code:: bash
+
+         # Pull and convert the docker container. This may take a while.
+         apptainer pull docker://nvcr.io/nvidia/pytorch:24.03-py3
+         # Run a command in the container, i.e. showing the pytorch version
+         apptainer exec --nv docker://nvcr.io/nvidia/pytorch:24.03-py3 python3 -c "import torch;print(torch.__version__);"
+
+      Alternatively, if you require more than just pytorch within the container you can create an `apptainer definition file <https://apptainer.org/docs/user/main/definition_files.html>`__.
+      E.g. for a container based on ``pytorch:24.03-py3`` which also installs HuggingFace Transformers ``4.37.0``, the following definition file could be used:
+
+      .. code:: singularity
+
+         Bootstrap: docker
+         From: nvcr.io/nvidia/pytorch:24.03-py3
+
+         %post
+           # Install other python dependencies, e.g. hugging face transformers
+           python3 -m pip install transformers[torch]==4.37.0
+
+         %test
+           # Print the torch version, if CUDA is enabled and which architectures
+           python3 -c "import torch;print(torch.__version__); print(torch.cuda.is_available());print(torch.cuda.get_arch_list());"
+           # Print the pytorch transformers version, demonstrating it is available.
+           python3 -c "import transformers;print(transformers.__version__);"
+
+      Assuming this is named ``pytorch-transformers.def``, a corresponding apptainer image file name ``pytorch-transformers.sif`` can then be created via:
+
+      .. code-block:: bash
+
+         apptainer build --nv pytorch-transformers.sif pytorch-transformers.def
+
+      Commands within this container can then be executed using ``apptainer exec``.
+      I.e. to see the version of transformers installed within the container:
+
+      .. code-block:: bash
+
+         apptainer exec --nv pytorch-transformers.sif python3 -c "import transformers;print(transformers.__version__);"
+
+      Or in this case due to the ``%test`` segment of the container, run the test command.
+
+      .. code-block:: bash
+
+         apptainer test --nv pytorch-transformers.sif
 
 
 Further Information

--- a/software/applications/r.rst
+++ b/software/applications/r.rst
@@ -4,7 +4,7 @@ R
 -
 
 .. |arch_availabilty_name| replace:: R
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 `R <https://www.r-project.org/>`__ is a free software environment for statistical computing and graphics.
 It is provided on the system by the ``r`` module(s), which make ``R`` and ``Rscript`` available for use.

--- a/software/applications/r.rst
+++ b/software/applications/r.rst
@@ -3,6 +3,9 @@
 R
 -
 
+.. |arch_availabilty_name| replace:: R
+.. include:: /common/ppc64le-only.rst
+
 `R <https://www.r-project.org/>`__ is a free software environment for statistical computing and graphics.
 It is provided on the system by the ``r`` module(s), which make ``R`` and ``Rscript`` available for use.
 

--- a/software/applications/tensorflow.rst
+++ b/software/applications/tensorflow.rst
@@ -7,52 +7,145 @@ TensorFlow
 
 TensorFlow can be installed through a number of python package managers such as :ref:`Conda<software-applications-conda>` or ``pip``.
 
-For use on Bede, the simplest method is to install TensorFlow using the :ref:`Open-CE Conda distribution<software-applications-open-ce>`.
+For use on Bede's ``ppc64le`` nodes, the simplest method is to install TensorFlow using the :ref:`Open-CE Conda distribution<software-applications-open-ce>`.
+
+For the ``aarch64`` nodes, using a NVIDIA provided `NGC Tensorflow container <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorflow>`__ is likely preferred.
 
 
 Installing via Conda (Open-CE)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-With a working Conda installation (see :ref:`Installing Miniconda<software-applications-conda-installing>`) the following instructions can be used to create a Python 3.8 conda environment named ``tf-env`` with the latest Open-CE provided TensorFlow:
+.. tabs::
 
-.. note:: 
+   .. group-tab:: ppc64le
 
-   TensorFlow installations via conda can be relatively large. Consider installing your miniconda (and therfore your conda environments) to the ``/nobackup`` file store.
+      With a working Conda installation (see :ref:`Installing Miniconda<software-applications-conda-installing>`) the following instructions can be used to create a Python 3.8 conda environment named ``tf-env`` with the latest Open-CE provided TensorFlow:
+
+      .. note:: 
+
+         TensorFlow installations via conda can be relatively large. Consider installing your miniconda (and therfore your conda environments) to the ``/nobackup`` file store.
 
 
-.. code-block:: bash
+      .. code-block:: bash
 
-   # Create a new conda environment named tf-env within your conda installation
-   conda create -y --name tf-env python=3.8
+         # Create a new conda environment named tf-env within your conda installation
+         conda create -y --name tf-env python=3.8
 
-   # Activate the conda environment
-   conda activate tf-env
+         # Activate the conda environment
+         conda activate tf-env
 
-   # Add the OSU Open-CE conda channel to the current environment config
-   conda config --env --prepend channels https://ftp.osuosl.org/pub/open-ce/current/
+         # Add the OSU Open-CE conda channel to the current environment config
+         conda config --env --prepend channels https://ftp.osuosl.org/pub/open-ce/current/
 
-   # Also use strict channel priority
-   conda config --env --set channel_priority strict
+         # Also use strict channel priority
+         conda config --env --set channel_priority strict
 
-   # Install the latest available version of Tensorflow
-   conda install -y tensorflow
+         # Install the latest available version of Tensorflow
+         conda install -y tensorflow
 
-In subsequent interactive sessions, and when submitting batch jobs which use TensorFlow, you will then need to re-activate the conda environment.
+      In subsequent interactive sessions, and when submitting batch jobs which use TensorFlow, you will then need to re-activate the conda environment.
 
-For example, to verify that TensorFlow is available and print the version:
+      For example, to verify that TensorFlow is available and print the version:
 
-.. code-block:: bash
+      .. code-block:: bash
 
-   # Activate the conda environment
-   conda activate tf-env
+         # Activate the conda environment
+         conda activate tf-env
 
-   # Invoke python
-   python3 -c "import tensorflow;print(tensorflow.__version__)"
+         # Invoke python
+         python3 -c "import tensorflow;print(tensorflow.__version__)"
 
-.. note::
+      .. note::
+         
+         The :ref:`Open-CE<software-applications-open-ce>` distribution of TensorFlow does not include IBM technologies such as DDL or LMS, which were previously available via :ref:`WMLCE<software-applications-wmlce>`. 
+         WMLCE is no longer supported.
+
+   .. group-tab:: aarch64
+
+      .. warning::
+
+         Conda and pip builds of TensorFlow for ``aarch64`` do not include CUDA support as of April 2024. For now, see :ref:`software-applications-tensorflow-ngc` or `build from source <https://tensorflow.org/install/source>`__.
+
+.. _software-applications-tensorflow-ngc:
+
+Using NGC TensorFlow Containers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. tabs::
+
+   .. group-tab:: ppc64le
+
+      .. warning::
+
+         NVIDIA do not provide ``ppc64le`` containers for TensorFlow through NGC. This method should only be used for ``aarch64`` partitions.
    
-   The :ref:`Open-CE<software-applications-open-ce>` distribution of TensorFlow does not include IBM technologies such as DDL or LMS, which were previously available via :ref:`WMLCE<software-applications-wmlce>`. 
-   WMLCE is no longer supported.
+   .. group-tab:: aarch64
+
+      NVIDIA provide docker containers with CUDA-enabled TensorFlow builds for ``x86_64`` and ``aarch64`` architectures through NGC.
+
+      The `NGC Tensorflow <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorflow>`__ containers have included Hopper support since ``22.09``.
+
+      For details of which TensorFlow version is provided by the each container release, see the `NGC TensorFlow container release notes <https://docs.nvidia.com/deeplearning/frameworks/tensorflow-release-notes>`__.
+
+
+      :ref:`software-tools-apptainer` can be used to convert and run docker containers, or to build an apptainer container based on a docker container. 
+      These can be built on the ``aarch64`` nodes in Bede using :ref:`software-tools-apptainer-rootless`.
+
+      .. note::
+
+         TensorFlow containers can consume a large amount of disk space. Consider setting :ref:`software-tools-apptainer-cachedir` to an appropriate location in ``/nobackup``, e.g. ``export APPTAINER_CACHEDIR=/nobackup/projects/${SLURM_JOB_ACCOUNT}/${USER}/apptainer-cache``.
+
+      .. note::
+
+         The following apptainer commands should be executed from an ``aarch64`` node only, i.e. on ``ghlogin``, ``gh`` or ``ghtest``.
+
+      Docker containers can be fetched and converted using ``apptainer pull``, prior to using ``apptainer exec`` to execute code within the container.
+
+      .. code:: bash
+
+         # Pull and convert the docker container. This may take a while.
+         apptainer pull docker://nvcr.io/nvidia/tensorflow:24.03-tf2-py3
+         # Run a command in the container, i.e. showing the TensorFlow version
+         apptainer exec --nv docker://nvcr.io/nvidia/tensorflow:24.03-tf2-py3 python3 -c "import tensorflow; print(tensorflow.__version__);"
+
+      Alternatively, if you require more than just TensorFlow within the container you can create an `apptainer definition file <https://apptainer.org/docs/user/main/definition_files.html>`__.
+      E.g. for a container based on ``tensorflow:24.03-tf2-py3`` which also installs HuggingFace Transformers ``4.37.0``, the following definition file could be used:
+
+      .. code:: singularity
+
+         Bootstrap: docker
+         From: nvcr.io/nvidia/tensorflow:24.03-tf2-py3
+
+         %post
+           # Install other python dependencies, e.g. hugging face transformers
+           python3 -m pip install transformers==4.37.0
+
+         %test
+           # Print the torch version, if CUDA is enabled and which architectures
+           python3 -c "import tensorflow; print(tensorflow.__version__); print(tensorflow.config.list_physical_devices('GPU'));"
+           # Print the TensorFlow transformers version, demonstrating it is available.
+           python3 -c "import transformers;print(transformers.__version__);"
+
+      Assuming this is named ``tf-transformers.def``, a corresponding apptainer image file name ``tf-transformers.sif`` can then be created via:
+
+      .. code-block:: bash
+
+         apptainer build --nv tf-transformers.sif tf-transformers.def
+
+      Commands within this container can then be executed using ``apptainer exec``.
+      I.e. to see the version of transformers installed within the container:
+
+      .. code-block:: bash
+
+         apptainer exec --nv tf-transformers.sif python3 -c "import transformers;print(transformers.__version__);"
+
+      Or in this case due to the ``%test`` segment of the container, run the test command.
+
+      .. code-block:: bash
+
+         apptainer test --nv tf-transformers.sif
+
 
 Further Information
 ~~~~~~~~~~~~~~~~~~~

--- a/software/applications/wmlce.rst
+++ b/software/applications/wmlce.rst
@@ -1,9 +1,12 @@
 .. _software-applications-wmlce:
 
+:orphan:
+
 IBM WMLCE (End of Life)
 =======================
 
-.. warning:: 
+.. admonition:: End of Life
+   :class: danger
 
    WMLCE was archived by IBM on 2020-11-10 and is no longer updated, maintained or supported.
    It is no longer available on bede due to the migration away from RHEL 7.

--- a/software/compilers/gcc.rst
+++ b/software/compilers/gcc.rst
@@ -8,16 +8,38 @@ The `GNU Compiler Collection (GCC) <https://gcc.gnu.org/>`__ is available on Bed
 The copies of GCC available as modules have been compiled with CUDA
 offload support:
 
-.. code-block:: bash
+.. tabs::
 
-   module load gcc/12.2
-   module load gcc/10.2.0
-   module load gcc/8.4.0
+   .. code-tab:: bash ppc64le
+
+      module load gcc/12.2
+      module load gcc/10.2.0
+      module load gcc/8.4.0
+
+   .. code-tab:: bash aarch64
+
+      module load gcc/13.2
+      module load gcc/12.2
 
 The version of GCC which is distributed with RHEL is also packaged as the ``gcc/native`` module, providing GCC ``8.5.0``. This does not include CUDA offload support.
 
-.. code-block:: bash
+.. tabs::
 
-   module load gcc/native
+   .. code-tab:: bash ppc64le
+
+      module load gcc/native
+
+   .. code-tab:: bash aarch64
+
+      module load gcc/native # provides 11.4.1 
+
 
 For further information please see the `GCC online documentation <https://gcc.gnu.org/onlinedocs/>`__.
+
+``aarch64`` psABI warnings
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When compiling on the ``aarch64`` Grace-Hopper nodes with ``--std=c++17``, GCC may emit platform specific ABI warnings about a change made in GCC 10.1.
+These warnings should only be a concern if you are linking objects compiled with ``GCC >= 10.1`` in c++17 mode with objects compiled with ``GCC < 10.1`` in c++17 mode.
+
+Use ``--Wno-psabi`` to suppress these warnings. 

--- a/software/compilers/ibmxl.rst
+++ b/software/compilers/ibmxl.rst
@@ -1,9 +1,8 @@
 IBM XL
 ------
 
-.. note:: 
-
-   The IBM XML compiler tool chain is only available on ppc64le nodes and partitions.
+.. |arch_availabilty_name| replace:: The IBM XL Compiler toolchain
+.. include:: /common/ppc64le-only.rst
 
 The `IBM XL C and C++ compiler family <https://www.ibm.com/products/c-and-c-plus-plus-compiler-family>`__ and `IBM XL Fortran compiler family <https://www.ibm.com/products/fortran-compiler-family>`__ are available on Bede, provided by the ``xl`` module family:
 

--- a/software/compilers/ibmxl.rst
+++ b/software/compilers/ibmxl.rst
@@ -2,7 +2,7 @@ IBM XL
 ------
 
 .. |arch_availabilty_name| replace:: The IBM XL Compiler toolchain
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 The `IBM XL C and C++ compiler family <https://www.ibm.com/products/c-and-c-plus-plus-compiler-family>`__ and `IBM XL Fortran compiler family <https://www.ibm.com/products/fortran-compiler-family>`__ are available on Bede, provided by the ``xl`` module family:
 

--- a/software/compilers/ibmxl.rst
+++ b/software/compilers/ibmxl.rst
@@ -1,6 +1,10 @@
 IBM XL
 ------
 
+.. note:: 
+
+   The IBM XML compiler tool chain is only available on ppc64le nodes and partitions.
+
 The `IBM XL C and C++ compiler family <https://www.ibm.com/products/c-and-c-plus-plus-compiler-family>`__ and `IBM XL Fortran compiler family <https://www.ibm.com/products/fortran-compiler-family>`__ are available on Bede, provided by the ``xl`` module family:
 
 .. code-block:: bash

--- a/software/compilers/llvm.rst
+++ b/software/compilers/llvm.rst
@@ -2,7 +2,7 @@ LLVM
 ----
 
 .. |arch_availabilty_name| replace:: The LLVM compiler toolchain
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 LLVM has been provided for use on the system by the ``llvm`` module.
 It has been built with CUDA GPU offloading support, allowing OpenMP

--- a/software/compilers/llvm.rst
+++ b/software/compilers/llvm.rst
@@ -1,6 +1,9 @@
 LLVM
 ----
 
+.. |arch_availabilty_name| replace:: The LLVM compiler toolchain
+.. include:: /common/ppc64le-only.rst
+
 LLVM has been provided for use on the system by the ``llvm`` module.
 It has been built with CUDA GPU offloading support, allowing OpenMP
 regions to run on a GPU using the ``target`` directive.

--- a/software/compilers/nvcc.rst
+++ b/software/compilers/nvcc.rst
@@ -1,7 +1,7 @@
 .. _software-compilers-nvcc:
 
-CUDA and NVCC
-=============
+NVCC (CUDA)
+===========
 
 `CUDA <https://developer.nvidia.com/cuda-zone>`__ and the ``nvcc`` CUDA/C++ compiler are provided for use on the system by the `cuda` modules.
 

--- a/software/compilers/nvcc.rst
+++ b/software/compilers/nvcc.rst
@@ -7,17 +7,30 @@ CUDA and NVCC
 
 Unlike other compiler modules, the cuda modules do not set ``CC`` or ``CXX`` environment variables. This is because ``nvcc`` can be used to compile device CUDA code in conjunction with a range of host compilers, such as GCC or LLVM clang.
 
-.. code-block:: bash
+.. tabs::
 
-   module load cuda
+   .. code-tab:: bash ppc64le
 
-   module load cuda/12.0.1
-   module load cuda/11.5.1
-   module load cuda/11.4.1
-   module load cuda/11.3.1
-   module load cuda/11.2.2
-   module load cuda/10.2.89
-   module load cuda/10.1.243
+      module load cuda
+
+      module load cuda/12.0.1
+      module load cuda/11.5.1
+      module load cuda/11.4.1
+      module load cuda/11.3.1
+      module load cuda/11.2.2
+      module load cuda/10.2.89
+      module load cuda/10.1.243
+
+   .. code-tab:: bash aarch64
+
+      module load cuda
+
+      module load cuda/12.3.2
+      module load cuda/12.2.2
+      module load cuda/12.1.1
+      module load cuda/11.8.0
+      module load cuda/11.7.0
+      module load cuda/11.7.1
 
 For further information please see the `CUDA Toolkit Archive <https://developer.nvidia.com/cuda-toolkit-archive>`__.
 
@@ -105,9 +118,19 @@ Bede contains NVIDIA Tesla V100 and Tesla T4 GPUs, which are `compute capability
 
 To generate optimised code for both GPU models in Bede, the following ``-gencode`` options can be passed to ``nvcc``:
 
-.. code-block:: bash
+.. tabs::
 
-   nvcc -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -o main main.cu
+   .. code-tab:: bash ppc64le
+
+      nvcc -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75 -o main main.cu
+
+   .. code-tab:: bash aarch64
+
+      # for nvcc >= 11.8
+      nvcc -gencode=arch=compute_90,code=sm_90 -o main main.cu
+      # for nvcc <  11.8
+      nvcc -gencode=arch=compute_80,code=compute_80 -o main main.cu
+
 
 Alternatively, to reduce compile time and binary size a single ``-gencode`` option can be passed. 
 

--- a/software/compilers/nvcc.rst
+++ b/software/compilers/nvcc.rst
@@ -130,7 +130,7 @@ Alternatively, to reduce compile time and binary size a single ``-gencode`` opti
 
 .. tabs:: 
 
-   .. tab:: ppc64le
+   .. group-tab:: ppc64le
 
       If only compute capability ``70`` is selected, code will be optimised for Volta GPUs, but will execute on Volta and Turing GPUs.
 
@@ -143,7 +143,7 @@ Alternatively, to reduce compile time and binary size a single ``-gencode`` opti
          # Optimise for T4 GPUs, not executable on V100 GPUs
          nvcc -gencode=arch=compute_75,code=sm_75 -o main main.cu
 
-   .. tab:: aarch64
+   .. group-tab:: aarch64
 
       ``aarch64`` nodes in Bede only contain Hopper GPUs, so there is only need to provide a single compute capability (``90``, or embedding PTX for compute capability ``80``)
 

--- a/software/compilers/nvcc.rst
+++ b/software/compilers/nvcc.rst
@@ -50,14 +50,8 @@ The C++ dialect used for host and device code can be controlled using the ``--st
 * ``c++03``
 * ``c++11``
 * ``c++14``
-
-CUDA ``>= 11.0`` also accepts
-
-* ``c++17``
-
-CUDA ``>= 12.0`` also accepts
-
-* ``c++20``
+* ``c++17`` (CUDA 11+)
+* ``c++20`` (CUDA 12+)
 
 The default C++ dialect depends on the host compiler, with ``nvcc`` matching the default dialect by the host c++ compiler.
 
@@ -126,24 +120,39 @@ To generate optimised code for both GPU models in Bede, the following ``-gencode
 
    .. code-tab:: bash aarch64
 
-      # for nvcc >= 11.8
+      # nvcc >= 11.8
       nvcc -gencode=arch=compute_90,code=sm_90 -o main main.cu
-      # for nvcc <  11.8
+      # nvcc <  11.8
       nvcc -gencode=arch=compute_80,code=compute_80 -o main main.cu
 
 
 Alternatively, to reduce compile time and binary size a single ``-gencode`` option can be passed. 
 
-If only compute capability ``70`` is selected, code will be optimised for Volta GPUs, but will execute on Volta and Turing GPUs.
+.. tabs:: 
 
-If only compute capability ``75`` is selected, code will be optimised for Turing GPUs, but it will not be executable on Volta GPUs.
+   .. tab:: ppc64le
 
-.. code-block:: bash
+      If only compute capability ``70`` is selected, code will be optimised for Volta GPUs, but will execute on Volta and Turing GPUs.
 
-   # Optimise for V100 GPUs, executable on T4 GPUs
-   nvcc -gencode=arch=compute_70,code=sm_70 -o main main.cu
-   # Optimise for T4 GPUs, not executable on V100 GPUs
-   nvcc -gencode=arch=compute_75,code=sm_75 -o main main.cu
+      If only compute capability ``75`` is selected, code will be optimised for Turing GPUs, but it will not be executable on Volta GPUs.
+
+      .. code-block:: bash
+
+         # Optimise for V100 GPUs, executable on T4 GPUs
+         nvcc -gencode=arch=compute_70,code=sm_70 -o main main.cu
+         # Optimise for T4 GPUs, not executable on V100 GPUs
+         nvcc -gencode=arch=compute_75,code=sm_75 -o main main.cu
+
+   .. tab:: aarch64
+
+      ``aarch64`` nodes in Bede only contain Hopper GPUs, so there is only need to provide a single compute capability (``90``, or embedding PTX for compute capability ``80``)
+
+      .. code-block:: bash
+
+         # nvcc >= 11.8
+         nvcc -gencode=arch=compute_90,code=sm_90 -o main main.cu
+         # nvcc <  11.8
+         nvcc -gencode=arch=compute_80,code=compute_80 -o main main.cu
 
 For more information on the use of ``-gencode``, ``-arch`` and ``-code`` please  see the `NVCC Documentation <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html>`__.
 
@@ -218,7 +227,7 @@ The automatic use of ``gcc`` / ``g++`` from the path may be overridden using the
 
 This option can be used to specify the directory in which the host compiler resides, and optionally may include the binary name itself, if for instance you wish to use ``clang++`` or ``xl`` as your host C++ compiler. 
 
-e.g. to use ``xlc++`` as the host compiler for the default CUDA module:
+e.g. to use ``xlc++`` as the host compiler for the default CUDA module (on ``ppc64le`` nodes):
 
 .. code-block:: bash
 
@@ -231,4 +240,4 @@ e.g. to use ``xlc++`` as the host compiler for the default CUDA module:
 This behaviour can be prevented using the ``--allow-unsupported-compiler`` / ``-allow-unsupported-compiler`` option (`docs <https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#file-and-path-specifications-allow-unsupported-compiler>`__), however, this may result in incorrect binaries. Use at your own risk.
 
 A list of officially supported host compilers can be found in the `CUDA Installation Guide for Linux <https://docs.nvidia.com/cuda/archive/11.5.2/cuda-installation-guide-linux/index.html>`__, for the appropriate CUDA version.
-For Bede, refer to the Power 9 section of the table with RHEL for the operating system.
+For Bede, refer to the Power 9 and aarch64 sections of the table with RHEL for the operating system.

--- a/software/compilers/nvhpc.rst
+++ b/software/compilers/nvhpc.rst
@@ -11,12 +11,20 @@ It provides the ``nvc``, ``nvc++`` and ``nvfortran`` compilers.
 
 This module also provides the `NCCL <https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/index.html>`__ and `NVSHMEM <https://docs.nvidia.com/hpc-sdk/nvshmem/index.html>`__ libraries, as well as the suite of math libraries typically included with the CUDA Toolkit, such as ``cublas``, ``cufft`` and ``nvblas``.
 
-.. code-block:: bash
+.. tabs::
 
-   module load nvhpc
+   .. code-tab:: bash ppc64le
 
-   module load nvhpc/23.1
-   module load nvhpc/22.1
-   module load nvhpc/21.5
+      module load nvhpc
+
+      module load nvhpc/23.1
+      module load nvhpc/22.1
+      module load nvhpc/21.5
+
+   .. code-tab:: bash aarch64
+
+      module load nvhpc
+
+      module load nvhpc/24.1
 
 For further information please see the `NVIDIA HPC SDK Documentation Archive <https://docs.nvidia.com/hpc-sdk/archive/>`__.

--- a/software/environments/cryo-em.rst
+++ b/software/environments/cryo-em.rst
@@ -3,6 +3,9 @@
 Cryo-EM Software Environment
 ============================
 
+.. |arch_availabilty_name| replace:: The Cryo-EM Software Environment
+.. include:: /common/ppc64le-only.rst
+
 Documentation on the the Cryo-EM Software Environment for Life Sciences is available :download:`here <Cryo-EM_Bede.pdf>`. 
 Note that this document is mainly based on the installation on `Satori <https://mit-satori.github.io>`_ and might have some inconsistencies with the Bede installation.
 

--- a/software/environments/cryo-em.rst
+++ b/software/environments/cryo-em.rst
@@ -4,7 +4,7 @@ Cryo-EM Software Environment
 ============================
 
 .. |arch_availabilty_name| replace:: The Cryo-EM Software Environment
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 Documentation on the the Cryo-EM Software Environment for Life Sciences is available :download:`here <Cryo-EM_Bede.pdf>`. 
 Note that this document is mainly based on the installation on `Satori <https://mit-satori.github.io>`_ and might have some inconsistencies with the Bede installation.

--- a/software/index.rst
+++ b/software/index.rst
@@ -9,7 +9,7 @@ These pages list software available on Bede and/or instructions on how to instal
 If you notice any omissions, errors or have any suggested changes to the documentation please create an `Issue <https://github.com/N8-CIR-Bede/documentation/issues>`__ or open a `Pull Request <https://github.com/N8-CIR-Bede/documentation/pulls>`__ on GitHub. 
 
 .. toctree::
-    :maxdepth: 3
+    :maxdepth: 2
     :name: softwaretoc
 
     applications/index

--- a/software/libraries/blas-lapack.rst
+++ b/software/libraries/blas-lapack.rst
@@ -18,7 +18,7 @@ The modules for each of these libraries provide some convenience environment var
       module load gcc essl/6.2
       $CC -o myprog myprog.c $N8CIR_LINALG_CFLAGS
 
-   .. tab:: aarch64
+   .. group-tab:: aarch64
 
       .. |arch_availabilty_name| replace:: ESSL
       .. include:: /common/ppc64le-only.rst

--- a/software/libraries/blas-lapack.rst
+++ b/software/libraries/blas-lapack.rst
@@ -3,12 +3,16 @@
 BLAS/LAPACK
 ===========
 
+
 The following numerical libraries provide optimised CPU implementations of BLAS and LAPACK on the system:
 
 - `ESSL <https://www.ibm.com/docs/en/essl>`__ (IBM Engineering and Scientific Subroutine Library)
 - `OpenBLAS <https://github.com/xianyi/OpenBLAS>`__
 
 The modules for each of these libraries provide some convenience environment variables: ``N8CIR_LINALG_CFLAGS`` contains the compiler arguments to link BLAS and LAPACK to C code; ``N8CIR_LINALG_FFLAGS`` contains the same to link to Fortran. When used with variables such as ``CC``, commands to build software can become entirely independent of what compilers and numerical libraries you have loaded, eg. for ESSL:
+
+.. |arch_availabilty_name| replace:: ESSL
+.. include:: /common/ppc64le-only.rst
 
 .. code-block:: bash
 

--- a/software/libraries/blas-lapack.rst
+++ b/software/libraries/blas-lapack.rst
@@ -20,11 +20,8 @@ The modules for each of these libraries provide some convenience environment var
 
    .. tab:: aarch64
 
-      .. admonition:: ppc64le partitions only
-         :class: warning
-
-         ESSL is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).
-
+      .. |arch_availabilty_name| replace:: ESSL
+      .. include:: /common/ppc64le-only.rst
 
 
 Or for OpenBLAS:

--- a/software/libraries/blas-lapack.rst
+++ b/software/libraries/blas-lapack.rst
@@ -11,19 +11,40 @@ The following numerical libraries provide optimised CPU implementations of BLAS 
 
 The modules for each of these libraries provide some convenience environment variables: ``N8CIR_LINALG_CFLAGS`` contains the compiler arguments to link BLAS and LAPACK to C code; ``N8CIR_LINALG_FFLAGS`` contains the same to link to Fortran. When used with variables such as ``CC``, commands to build software can become entirely independent of what compilers and numerical libraries you have loaded, eg. for ESSL:
 
-.. |arch_availabilty_name| replace:: ESSL
-.. include:: /common/ppc64le-only.rst
+.. tabs::
 
-.. code-block:: bash
+   .. code-tab:: bash ppc64le
 
-   module load gcc essl/6.2
-   $CC -o myprog myprog.c $N8CIR_LINALG_CFLAGS
+      module load gcc essl/6.2
+      $CC -o myprog myprog.c $N8CIR_LINALG_CFLAGS
+
+   .. tab:: aarch64
+
+      .. admonition:: ppc64le partitions only
+         :class: warning
+
+         ESSL is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).
+
 
 
 Or for OpenBLAS:
 
-.. code-block:: bash
+.. tabs::
 
-   module load gcc openblas/0.3.10
-   $CC -o myprog myprog.c $N8CIR_LINALG_CFLAGS
+   .. code-tab:: bash ppc64le
+
+      module load gcc openblas/0.3.10
+      $CC -o myprog myprog.c $N8CIR_LINALG_CFLAGS
+
+   .. code-tab:: bash aarch64
+
+      module load gcc openblas/0.3.26
+      $CC -o myprog myprog.c $N8CIR_LINALG_CFLAGS
+
+      # or 
+      module load gcc openblas/0.3.26omp
+      $CC -o myprog myprog.c $N8CIR_LINALG_CFLAGS
+
+
+
 

--- a/software/libraries/boost.rst
+++ b/software/libraries/boost.rst
@@ -5,8 +5,17 @@ Boost
 
 A centrally-installed version is available via the modules system, which can be loaded as follows: 
 
-.. code-block:: bash
+.. tabs::
 
-    module load boost
-    module load boost/1.81.0
-    module load boost/1.74.0
+   .. code-tab:: bash ppc64le
+
+      module load boost
+
+      module load boost/1.81.0
+      module load boost/1.74.0
+
+   .. code-tab:: bash aarch64
+
+      module load boost
+      
+      module load boost/1.84.0

--- a/software/libraries/fftw.rst
+++ b/software/libraries/fftw.rst
@@ -7,7 +7,16 @@ FFTW
 
 A centrally-installed version of FFTW can be loaded via ``module``: 
 
-.. code-block:: bash
+.. tabs::
 
-    module load fftw
-    module load fftw/3.3.8
+   .. code-tab:: bash ppc64le
+
+      module load fftw
+
+      module load fftw/3.3.8
+
+   .. code-tab:: bash aarch64
+
+      module load fftw
+      
+      module load fftw/3.3.10

--- a/software/libraries/hdf5.rst
+++ b/software/libraries/hdf5.rst
@@ -7,10 +7,19 @@ When loaded in conjunction with an MPI module such as ``openmpi``, the
 ``hdf5`` module provides both the serial and parallel versions of the
 library. 
 
-.. code-block:: bash
+.. tabs::
+      
+   .. code-tab:: bash ppc64le
 
-   module load hdf5
-   module load hdf5/1.10.7
+      module load hdf5
+
+      module load hdf5/1.10.7
+
+   .. code-tab:: bash aarch64
+
+      module load hdf5
+      
+      module load hdf5/1.10.11
 
 .. _software-libraries-hdf5-known-issues:
 

--- a/software/libraries/mpi.rst
+++ b/software/libraries/mpi.rst
@@ -55,7 +55,7 @@ MVAPICH2 is provided by the `mvapich2` module(s):
 
       module load mvapich2/2.3.5-2
 
-   .. tab:: aarch64
+   .. group-tab:: aarch64
 
       .. admonition:: ppc64le partitions only
          :class: warning
@@ -79,7 +79,7 @@ Unlike the ``openmpi`` and ``mvapich2`` modules, ``mvapich2-gdr`` does not adapt
 
       module load mvapich2-gdr/2.3.6 gcc/8.4.0 cuda/11.3.1
 
-   .. tab:: aarch64
+   .. group-tab:: aarch64
 
       .. include:: /common/ppc64le-only.rst
 

--- a/software/libraries/mpi.rst
+++ b/software/libraries/mpi.rst
@@ -15,39 +15,77 @@ We commit to the following convention for all MPIs we provide as modules:
 
 CUDA-enabled MPI is available through OpenMPI, when a cuda module is loaded alongside ``openmpi``, I.e.
 
-.. code-block:: bash
+.. tabs::
 
-   module load gcc cuda openmpi
+   .. code-tab:: bash ppc64le
+
+      module load gcc cuda openmpi
+
+   .. code-tab:: bash aarch64
+
+      module load gcc cuda openmpi
 
 OpenMPI is provided by the ``openmpi`` module(s):
 
-.. code-block:: bash
 
-   module load openmpi
-   module load openmpi/4.0.5
+.. tabs::
 
+   .. code-tab:: bash ppc64le
+
+      module load openmpi
+      
+      module load openmpi/4.0.5
+
+   .. code-tab:: bash ppc64le
+
+      module load openmpi
+      
+      module load openmpi/4.1.6
 
 .. |arch_availabilty_name| replace:: MVAPICH2
-.. include:: /common/ppc64le-only.rst
+.. admonition:: ppc64le partitions only
+         :class: warning
 
+         MVAPICH2 is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).
+         
 MVAPICH2 is provided by the `mvapich2` module(s):
 
-.. code-block:: bash
+.. tabs::
 
-   module load mvapich2/2.3.5-2
+   .. code-tab:: bash ppc64le
+
+      module load mvapich2
+
+      module load mvapich2/2.3.5-2
+
+   .. tab:: aarch64
+
+      .. admonition:: ppc64le partitions only
+         :class: warning
+
+         MVAPICH2 is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).
 
 .. note::
 
    There are a number of issues with OpenMPI 4 and the one-sided MPI communication features added by the MPI-3 standard. These features are typically useful when combined with GPUs, due to the asynchronous nature of the CUDA and OpenCL programming models.
 
-   For codes that require these features, we currently recommend using the ``mvapich2`` module.
+   For codes that require these features, we currently recommend using the ``mvapich2`` module on ``ppc64le`` nodes/partitions.
 
-We also offer the ``mvapich2-gdr/2.3.6`` module. This is a version of MVAPICH2 that is specifically designed for machines like Bede, providing optimised communications directly between GPUs - even when housed in different compute nodes.
+We also offer the ``mvapich2-gdr/2.3.6`` module on ``ppc64le`` nodes/partitions. This is a version of MVAPICH2 that is specifically designed for machines like Bede, providing optimised communications directly between GPUs - even when housed in different compute nodes.
 
 Unlike the ``openmpi`` and ``mvapich2`` modules, ``mvapich2-gdr`` does not adapt itself to the currently loaded compiler and CUDA modules. This version of the software was built using GCC 8.4.1 and CUDA 11.3.
 
-.. code-block:: bash
-   
-   module load mvapich2-gdr/2.3.6 gcc/8.4.0 cuda/11.3.1
+.. tabs::
+
+   .. code-tab:: bash ppc64le
+
+      module load mvapich2-gdr/2.3.6 gcc/8.4.0 cuda/11.3.1
+
+   .. tab:: aarch64
+
+      .. admonition:: ppc64le partitions only
+         :class: warning
+
+         ``mvapich2-gdr`` is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).
 
 Further information can be found on the `MVAPICH2-GDR <http://mvapich.cse.ohio-state.edu/userguide/gdr/>`__ pages.

--- a/software/libraries/mpi.rst
+++ b/software/libraries/mpi.rst
@@ -43,11 +43,8 @@ OpenMPI is provided by the ``openmpi`` module(s):
       module load openmpi/4.1.6
 
 .. |arch_availabilty_name| replace:: MVAPICH2
-.. admonition:: ppc64le partitions only
-         :class: warning
+.. include:: /common/ppc64le-only.rst
 
-         MVAPICH2 is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).
-         
 MVAPICH2 is provided by the `mvapich2` module(s):
 
 .. tabs::
@@ -60,10 +57,7 @@ MVAPICH2 is provided by the `mvapich2` module(s):
 
    .. tab:: aarch64
 
-      .. admonition:: ppc64le partitions only
-         :class: warning
-
-         MVAPICH2 is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).
+      .. include:: /common/ppc64le-only.rst
 
 .. note::
 
@@ -83,9 +77,6 @@ Unlike the ``openmpi`` and ``mvapich2`` modules, ``mvapich2-gdr`` does not adapt
 
    .. tab:: aarch64
 
-      .. admonition:: ppc64le partitions only
-         :class: warning
-
-         ``mvapich2-gdr`` is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).
+      .. include:: /common/ppc64le-only.rst
 
 Further information can be found on the `MVAPICH2-GDR <http://mvapich.cse.ohio-state.edu/userguide/gdr/>`__ pages.

--- a/software/libraries/mpi.rst
+++ b/software/libraries/mpi.rst
@@ -57,7 +57,11 @@ MVAPICH2 is provided by the `mvapich2` module(s):
 
    .. tab:: aarch64
 
-      .. include:: /common/ppc64le-only.rst
+      .. admonition:: ppc64le partitions only
+         :class: warning
+
+         mvapich2-gdr is only provided on ``ppc64le`` partitions/nodes (``gpu``, ``infer``, ``test``).
+         However, we plan to provide a ``mvapich-plus`` Smodule in future to provide this functionality. In the meantime, if this is of interest, please contact us.
 
 .. note::
 

--- a/software/libraries/mpi.rst
+++ b/software/libraries/mpi.rst
@@ -27,6 +27,9 @@ OpenMPI is provided by the ``openmpi`` module(s):
    module load openmpi/4.0.5
 
 
+.. |arch_availabilty_name| replace:: MVAPICH2
+.. include:: /common/ppc64le-only.rst
+
 MVAPICH2 is provided by the `mvapich2` module(s):
 
 .. code-block:: bash

--- a/software/libraries/netcdf.rst
+++ b/software/libraries/netcdf.rst
@@ -4,7 +4,7 @@ NetCDF
 ======
 
 .. |arch_availabilty_name| replace:: NetCDF
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 `Network Common Data Form (NetCDF) <https://www.unidata.ucar.edu/software/netcdf/>`__ is a set of software libraries and machine independent data formats for array-orientated scientific data.
 

--- a/software/libraries/netcdf.rst
+++ b/software/libraries/netcdf.rst
@@ -3,6 +3,9 @@
 NetCDF
 ======
 
+.. |arch_availabilty_name| replace:: NetCDF
+.. include:: /common/ppc64le-only.rst
+
 `Network Common Data Form (NetCDF) <https://www.unidata.ucar.edu/software/netcdf/>`__ is a set of software libraries and machine independent data formats for array-orientated scientific data.
 
 A centrally installed version of NetCDF is provided on Bede by the ``netcdf`` module(s).

--- a/software/libraries/nvtoolsext.rst
+++ b/software/libraries/nvtoolsext.rst
@@ -11,7 +11,7 @@ These markers and ranges can be used to increase the usability of the NVIDIA pro
 
 The location of the headers and shared libraries may vary between Operating Systems, and CUDA installation (i.e. CUDA toolkit, PGI compilers or HPC SDK).
 
-On Bede, nvToolsExt is provided by the :ref:`CUDA <software-compilers-nvcc>` and :ref:`NVHPC <software-compilers-nvhpc>` modules:
+On Bede, ``nvToolsExt`` is provided by the :ref:`CUDA <software-compilers-nvcc>` and :ref:`NVHPC <software-compilers-nvhpc>` modules:
 
 .. code-block:: bash
     

--- a/software/libraries/plumed.rst
+++ b/software/libraries/plumed.rst
@@ -4,7 +4,7 @@ PLUMED
 ------
 
 .. |arch_availabilty_name| replace:: PLUMED
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 `PLUMED <https://www.plumed.org/>`__, the community-developed PLUgin for MolEcular Dynamics, is a an open-source, community-developed library that provides a wide range of different methods, which include:
 

--- a/software/libraries/plumed.rst
+++ b/software/libraries/plumed.rst
@@ -3,6 +3,9 @@
 PLUMED
 ------
 
+.. |arch_availabilty_name| replace:: PLUMED
+.. include:: /common/ppc64le-only.rst
+
 `PLUMED <https://www.plumed.org/>`__, the community-developed PLUgin for MolEcular Dynamics, is a an open-source, community-developed library that provides a wide range of different methods, which include:
 
 * enhanced-sampling algorithms

--- a/software/libraries/vtk.rst
+++ b/software/libraries/vtk.rst
@@ -4,7 +4,7 @@ VTK
 ---
 
 .. |arch_availabilty_name| replace:: VTK
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 `The Visualization Toolkit (VTK) <https://vtk.org/>`__ is open source software for manipulating and displaying scientific data.
 

--- a/software/libraries/vtk.rst
+++ b/software/libraries/vtk.rst
@@ -3,6 +3,9 @@
 VTK
 ---
 
+.. |arch_availabilty_name| replace:: VTK
+.. include:: /common/ppc64le-only.rst
+
 `The Visualization Toolkit (VTK) <https://vtk.org/>`__ is open source software for manipulating and displaying scientific data.
 
 The ``vtk`` module can be loaded by one of the following:

--- a/software/projects/hecbiosim.rst
+++ b/software/projects/hecbiosim.rst
@@ -4,7 +4,7 @@ HECBioSim
 =========
 
 .. |arch_availabilty_name| replace:: The HECBioSim Software environment
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 The `HEC BioSim consortium <http://www.hecbiosim.ac.uk/>`__ focusses on molecular simulations, at a variety of time and length scales but based on well-defined physics to complement experiment.
 The unique insight they can provide gives molecular level understanding of how biological macromolecules function.

--- a/software/projects/hecbiosim.rst
+++ b/software/projects/hecbiosim.rst
@@ -3,6 +3,9 @@
 HECBioSim
 =========
 
+.. |arch_availabilty_name| replace:: The HECBioSim Software environment
+.. include:: /common/ppc64le-only.rst
+
 The `HEC BioSim consortium <http://www.hecbiosim.ac.uk/>`__ focusses on molecular simulations, at a variety of time and length scales but based on well-defined physics to complement experiment.
 The unique insight they can provide gives molecular level understanding of how biological macromolecules function.
 Simulations are crucial in analysing protein folding, mechanisms of biological catalysis, and how membrane proteins interact with lipid bilayers.

--- a/software/projects/ibm-collaboration.rst
+++ b/software/projects/ibm-collaboration.rst
@@ -3,6 +3,10 @@
 IBM Collaboration
 =================
 
+.. |arch_availabilty_name| replace:: The "IBM Collaboration" Software environment
+.. include:: /common/ppc64le-only.rst
+
+
 On Bede, the ``ibm-collaboration`` project provides several software packages which were produced in collaboration with the system vendor `IBM <https://www.ibm.com/>`__.
 
 * :ref:`Cryo-EM <software-environments-cryoem>` - a collection of software packages for life sciences including:

--- a/software/projects/ibm-collaboration.rst
+++ b/software/projects/ibm-collaboration.rst
@@ -4,7 +4,7 @@ IBM Collaboration
 =================
 
 .. |arch_availabilty_name| replace:: The "IBM Collaboration" Software environment
-.. include:: /common/ppc64le-only.rst
+.. include:: /common/ppc64le-only-sidebar.rst
 
 
 On Bede, the ``ibm-collaboration`` project provides several software packages which were produced in collaboration with the system vendor `IBM <https://www.ibm.com/>`__.

--- a/software/tools/apptainer.rst
+++ b/software/tools/apptainer.rst
@@ -36,6 +36,7 @@ Although Apptainer and Singularity share a common history, there are a number of
 * The ``singularity`` command/binary is still available, but is just a symlink to ``apptainer``
 * The ``library://`` protocol is not supported by apptainer's default configuration. See `Restoring pre-Apptainer library behaviour <https://apptainer.org/docs/user/latest/endpoint.html#restoring-pre-apptainer-library-behavior>`_ for more information.
 
+.. _software-tools-apptainer-rootless:
 
 Rootless Container Builds
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -43,6 +44,8 @@ Rootless Container Builds
 The apptainer installation on Bede's ``aarch64`` nodes supports the creation of container images from apptainer definition files or docker containers without the need for root.
 
 I.e. it is possible to build your ``aarch64`` containers on the ``ghlogin`` interactive sessions rather than having to create containers on ``aarch64`` machines elsewhere and copying them into bede.
+
+.. _software-tools-apptainer-cachedir:
 
 ``APPTAINER_CACHEDIR``
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/software/tools/apptainer.rst
+++ b/software/tools/apptainer.rst
@@ -1,0 +1,39 @@
+.. _software-tools-apptainer:
+
+Apptainer
+---------
+
+`Apptainer <https://apptainer.org/>`__ is a container platform similar to `Docker <https://www.docker.com/>`__, previously known as Singularity. 
+It is a widely used container system for HPC, which allows you to create and run containers that package up pieces of software in a way that is portable and reproducible.
+
+Container platforms allow users to create and use container images, which are self-contained software stacks.
+
+.. admonition:: aarch64 partitions only
+   :class: warning
+
+   Apptainer is only available on ``aarch64`` nodes/partitions within Bede. 
+
+   For ``ppc64le`` partitions, please see :ref:`Singularity CE<software-tools-singularity>`.
+
+Apptainer is provided by default on ``aarch64`` nodes/partitions, and can be used without loading any modules.
+
+.. code-block::bash
+
+   apptainer --version
+
+.. note::
+   Container images are not portable across CPU architectures. Containers created on ``x86_64`` machines may not be compatible with the ``ppc64le`` and ``aarch64`` nodes in Bede.
+
+
+For more information on how to use singularity, please see the `Apptainer Documentation <https://apptainer.org/docs/>`__.
+
+
+Rootless Container Builds
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The apptainer installation on Bede's ``aarch64`` nodes supports the creation of container images from apptainer definition files or docker containers without the need for root.
+
+I.e. it is possible to build your ``aarch64`` containers on the ``ghlogin`` interactive sessions rather than having to create containers on ``aarch64`` machines elsewhere and copying them into bede.
+
+Container images for GPU acceleated code are often very large, and if creating containers based on a docker image multiple copies of th container will exist in your file stores.
+Consider setting the ``APPTAINER_CACHEDIR`` environment variable to a location in ``/nobackup`` or ``/projects`` to avoid filling your home directory.

--- a/software/tools/apptainer.rst
+++ b/software/tools/apptainer.rst
@@ -27,6 +27,15 @@ Apptainer is provided by default on ``aarch64`` nodes/partitions, and can be use
 
 For more information on how to use singularity, please see the `Apptainer Documentation <https://apptainer.org/docs/>`__.
 
+Differences from Singularity CE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Although Apptainer and Singularity share a common history, there are a number of important differences, as `documented by apptainer <https://apptainer.org/docs/user/latest/singularity_compatibility.html>`_, including:
+    
+* ``SINGULARITY_`` prefixed environment variables may issues warnings, preferring to be prefixed with ``APPTAINER_``
+* The ``singularity`` command/binary is still available, but is just a symlink to ``apptainer``
+* The ``library://`` protocol is not supported by apptainer's default configuration. See `Restoring pre-Apptainer library behaviour <https://apptainer.org/docs/user/latest/endpoint.html#restoring-pre-apptainer-library-behavior>`_ for more information.
+
 
 Rootless Container Builds
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,6 +43,9 @@ Rootless Container Builds
 The apptainer installation on Bede's ``aarch64`` nodes supports the creation of container images from apptainer definition files or docker containers without the need for root.
 
 I.e. it is possible to build your ``aarch64`` containers on the ``ghlogin`` interactive sessions rather than having to create containers on ``aarch64`` machines elsewhere and copying them into bede.
+
+``APPTAINER_CACHEDIR``
+^^^^^^^^^^^^^^^^^^^^^^
 
 Container images for GPU acceleated code are often very large, and if creating containers based on a docker image multiple copies of th container will exist in your file stores.
 Consider setting the ``APPTAINER_CACHEDIR`` environment variable to a location in ``/nobackup`` or ``/projects`` to avoid filling your home directory.

--- a/software/tools/cmake.rst
+++ b/software/tools/cmake.rst
@@ -10,11 +10,17 @@ The suite of CMake tools were created by `Kitware <https://www.kitware.com/>`__ 
 CMake is part of Kitware’s collection of commercially supported `open-source platforms <https://www.kitware.com/platforms/>`__ for software development.
 
 
-.. code-block:: bash
+.. tabs::
 
-    module load cmake
-    module load cmake/3.18.4
+    .. code-tab:: bash ppc64le
 
-Once loaded, the ``cmake``, ``ccmake``, ``cpack`` and ``ctest`` binaries are available for use, to configure, build and test software which uses CMake as the build system. 
+        module load cmake
+        module load cmake/3.18.4
+
+    .. tab:: aarch64
+
+        On ``aarch64`` nodes, CMake ``3.20.2`` is provided by default.
+
+This provides the ``cmake``, ``ccmake``, ``cpack`` and ``ctest`` binaries are available for use, to configure, build and test software which uses CMake as the build system. 
 
 For more information, see the `online documentation <https://cmake.org/cmake/help/v3.18/>`__.

--- a/software/tools/cmake.rst
+++ b/software/tools/cmake.rst
@@ -17,7 +17,7 @@ CMake is part of Kitware’s collection of commercially supported `open-source p
         module load cmake
         module load cmake/3.18.4
 
-    .. tab:: aarch64
+    .. group-tab:: aarch64
 
         On ``aarch64`` nodes, CMake ``3.20.2`` is provided by default.
 

--- a/software/tools/make.rst
+++ b/software/tools/make.rst
@@ -10,7 +10,7 @@ Make gets its knowledge of how to build your program from a file called the make
 
 .. tabs::
 
-   .. tab:: ppc64le
+   .. group-tab:: ppc64le
 
       On Bede's ``ppc64le`` nodes, ``make 4.2`` is provided by default, and 
       A more recent version of ``make``, is provided by the ``make`` family of modules. 
@@ -20,7 +20,7 @@ Make gets its knowledge of how to build your program from a file called the make
          module load make
          module load make/4.3
 
-   .. tab:: aarch64
+   .. group-tab:: aarch64
 
       On the ``aarch64`` nodes, ``make 4.3`` is provided by default without the need for a ``module load``
 

--- a/software/tools/make.rst
+++ b/software/tools/make.rst
@@ -8,12 +8,20 @@ Make
 Make gets its knowledge of how to build your program from a file called the makefile, which lists each of the non-source files and how to compute it from other files. When you write a program, you should write a makefile for it, so that it is possible to use Make to build and install the program.
 
 
-On Bede, ``make 4.2`` is provided by default. 
-A more recent version of ``make``, is provided by the ``make`` family of modules. 
+.. tabs::
 
-.. code-block:: bash
+   .. tab:: ppc64le
 
-    module load make
-    module load make/4.3
+      On Bede's ``ppc64le`` nodes, ``make 4.2`` is provided by default, and 
+      A more recent version of ``make``, is provided by the ``make`` family of modules. 
+
+      .. code-block:: bash
+
+         module load make
+         module load make/4.3
+
+   .. tab:: aarch64
+
+      On the ``aarch64`` nodes, ``make 4.3`` is provided by default without the need for a ``module load``
 
 For more information on the usage of ``make``, see the `online documentation <https://www.gnu.org/software/make/manual/>`__ or run ``man make`` after loading the module.

--- a/software/tools/nsight-compute.rst
+++ b/software/tools/nsight-compute.rst
@@ -11,21 +11,36 @@ Remote GUI is not available on Bede, but profile data can be generated on Bede v
 
 You should use a versions of ``ncu`` that is at least as new as the CUDA toolkit used to compile your application (if appropriate).
 
-.. code-block:: bash
+.. tabs:: 
 
-   module load nsight-compute/2022.4.1 # provides ncu 2022.4.1
-   module load nsight-compute/2022.1.0 # provides ncu 2022.1.0
-   module load nsight-compute/2020.2.1 # provides ncu 2020.2.1
+   .. code-tab:: bash ppc64le
 
-   module load cuda/12.0.1 # provides ncu 2022.4.1
-   module load cuda/11.5.1 # provides ncu 2021.3.1
-   module load cuda/11.4.1 # provides ncu 2021.2.1
-   module load cuda/11.3.1 # provides ncu 2021.1.1
-   module load cuda/11.2.2 # provides ncu 2020.3.1
+      module load nsight-compute/2022.4.1
+      module load nsight-compute/2022.1.0
+      module load nsight-compute/2020.2.1
 
-   module load nvhpc/23.1  # provides ncu 2022.4.0
-   module load nvhpc/22.1  # provides ncu 2021.3.0
-   module load nvhpc/21.5  # provides ncu 2021.1.0
+      module load cuda/12.0.1 # provides ncu 2022.4.1
+      module load cuda/11.5.1 # provides ncu 2021.3.1
+      module load cuda/11.4.1 # provides ncu 2021.2.1
+      module load cuda/11.3.1 # provides ncu 2021.1.1
+      module load cuda/11.2.2 # provides ncu 2020.3.1
+
+      module load nvhpc/23.1  # provides ncu 2022.4.0
+      module load nvhpc/22.1  # provides ncu 2021.3.0
+      module load nvhpc/21.5  # provides ncu 2021.1.0
+   
+   .. code-tab:: bash aarch64
+
+      module load nsight-systems/2023.4.1
+
+      module load cuda/12.3.2 # provides ncu 2023.3.1
+      module load cuda/12.2.2 # provides ncu 2023.2.2
+      module load cuda/12.1.1 # provides ncu 2023.1.1
+      module load cuda/11.8.0 # provides ncu 2022.3.0
+      module load cuda/11.7.1 # provides ncu 2022.1.0
+      module load cuda/11.7.0 # provides ncu 2022.2.0
+
+      module load nvhpc/24.1  # provides ncu 2023.3.1
 
 
 Consider compiling your CUDA application using ``nvcc`` with ``-lineinfo`` or ``--generate-line-info`` to generate line-level profile information.

--- a/software/tools/nsight-systems.rst
+++ b/software/tools/nsight-systems.rst
@@ -12,21 +12,36 @@ The GUI is not available on Bede.
 On Bede, Nsight Systems is provided by a number of modules, with differing versions of ``nsys``. 
 You should use a versions of ``nsys`` that is at least as new as the CUDA toolkit used to compile your application (if appropriate).
 
-.. code-block:: bash
+.. tabs:: 
 
-   module load nsight-systems/2023.1.1 # provides nsys 2023.1.1
-   module load nsight-systems/2022.1.1 # provides nsys 2022.1.1
-   module load nsight-systems/2020.3.1 # provides nsys 2020.3.1
+   .. code-tab:: bash ppc64le
 
-   module load cuda/12.0.1 # provides nsys 2022.4.2
-   module load cuda/11.5.1 # provides nsys 2021.3.3
-   module load cuda/11.4.1 # provides nsys 2021.2.4
-   module load cuda/11.3.1 # provides nsys 2021.1.3
-   module load cuda/11.2.2 # provides nsys 2020.4.3
+      module load nsight-systems/2023.1.1
+      module load nsight-systems/2022.1.1
+      module load nsight-systems/2020.3.1
 
-   module load nvhpc/23.1  # provides nsys 2022.5.1
-   module load nvhpc/22.1  # provides nsys 2021.5.1
-   module load nvhpc/21.5  # provides nsys 2021.2.1
+      module load cuda/12.0.1 # provides nsys 2022.4.2
+      module load cuda/11.5.1 # provides nsys 2021.3.3
+      module load cuda/11.4.1 # provides nsys 2021.2.4
+      module load cuda/11.3.1 # provides nsys 2021.1.3
+      module load cuda/11.2.2 # provides nsys 2020.4.3
+
+      module load nvhpc/23.1  # provides nsys 2022.5.1
+      module load nvhpc/22.1  # provides nsys 2021.5.1
+      module load nvhpc/21.5  # provides nsys 2021.2.1
+
+   .. code-tab:: bash aarch64
+
+      module load nsight-systems/2023.4.1
+
+      module load cuda/12.3.2 # provides nsys 2023.3.3
+      module load cuda/12.2.2 # provides nsys 2023.2.3
+      module load cuda/12.1.1 # provides nsys 2023.1.2
+      module load cuda/11.8.0 # provides nsys 2022.4.2
+      module load cuda/11.7.1 # provides nsys 2022.1.3
+      module load cuda/11.7.0 # provides nsys 2022.1.3
+
+      module load nvhpc/24.1  # provides nsys 2023.4.1
 
 To generate an application timeline with Nsight Systems CLI (``nsys``):
 

--- a/software/tools/singularity.rst
+++ b/software/tools/singularity.rst
@@ -1,22 +1,30 @@
 .. _software-tools-singularity:
 
-Singularity
------------
+Singularity CE
+--------------
 
-`Singularity <https://sylabs.io/singularity/>`__ (and `Apptainer <https://apptainer.org/>`__) is a container platform similar to `Docker <https://www.docker.com/>`__. 
-Singularity is the most widely used container system for HPC.
+`Singularity CE <https://sylabs.io/singularity/>`__ (and `Apptainer <https://apptainer.org/>`__) is a container platform similar to `Docker <https://www.docker.com/>`__. 
+Singularity is one of the most widely used container system for HPC.
 It allows you to create and run containers that package up pieces of software in a way that is portable and reproducible.
 
 Container platforms allow users to create and use container images, which are self-contained software stacks.
 
-.. note::
-   As Bede is a Power 9 Architecture (``ppc64le``) machine, containers created on more common ``x86_64`` machines may not be compatible. 
+.. admonition:: ppc64le partitions only
+   :class: warning
+
+   Singularity CE is only available on ``ppc64le`` nodes/partitions within Bede. 
+
+   For ``aarch64`` partitions, please see :ref:`Apptainer<software-tools-apptainer>`.
 
 
-Singularity-ce is provided by default, and can be used without loading any modules.
+
+Singularity CE is provided by default on ``ppc64le`` nodes/partitions, and can be used without loading any modules.
 
 .. code-block::bash
 
    singularity --version
 
-For more information on how to use singularity, please see the `Singularity Documentation <https://apptainer.org/docs-legacy/>`__.
+.. note::
+   Container images are not portable across CPU architectures. Containers created on ``x86_64`` machines may not be compatible with the ``ppc64le`` and ``aarch64`` nodes in Bede.
+
+For more information on how to use singularity, please see the `Singularity Documentation <https://sylabs.io/docs/>`__.

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -326,7 +326,7 @@ Multiple nodes (MPI)
 ^^^^^^^^^^^^^^^^^^^^
 
 Example job script for programs using MPI to take advantage of multiple
-CPUs/GPUs across one or more machines:
+CPUs/GPUs across one or more machines, via ``bede-mpirun``:
 
 .. tabs::
 
@@ -354,41 +354,6 @@ CPUs/GPUs across one or more machines:
          echo "end of job"
 
 
-      The ``bede-mpirun`` command takes both ordinary ``mpirun`` arguments and
-      the special ``--bede-par <distrib>`` option, allowing control over how
-      MPI jobs launch, e.g. one MPI rank per CPU core or GPU.
-
-      The formal specification of the option is:
-      ``--bede-par <rank_distrib>[:<thread_distrib>]`` and it defaults to
-      ``1ppc:1tpt``
-
-      Where ``<rank_distrib>`` can take ``1ppn`` (one process per node),
-      ``1ppg`` (one process per GPU), ``1ppc`` (one process per CPU core) or
-      ``1ppt`` (one process per CPU thread).
-
-      And ``<thread_distrib>`` can take ``1tpc`` (set ``OMP_NUM_THREADS`` to
-      the number of cores available to each process), ``1tpt`` (set
-      ``OMP_NUM_THREADS`` to the number of hardware threads available to each
-      process) or ``none`` (set ``OMP_NUM_THREADS=1``)
-
-      Examples:
-
-      .. code-block:: bash
-
-         # - One MPI rank per node:
-         bede-mpirun --bede-par 1ppn <mpirun_options> <program>
-
-         # - One MPI rank per gpu:
-         bede-mpirun --bede-par 1ppg <mpirun_options> <program>
-
-         # - One MPI rank per core:
-         bede-mpirun --bede-par 1ppc <mpirun_options> <program>
-
-         # - One MPI rank per hwthread:
-         bede-mpirun --bede-par 1ppt <mpirun_options> <program>
-
-      .. _usage-maximum-job-runtime:
-
    .. group-tab:: aarch64
 
       .. code-block:: bash
@@ -402,24 +367,58 @@ CPUs/GPUs across one or more machines:
 
          # Node resources:
 
-         #SBATCH --partition=gh    # Choose either "gh" or"ghtest" partition type
+         #SBATCH --partition=gh     # Choose either "gh" or"ghtest" partition type
          #SBATCH --nodes=2          # Resources from two nodes
          #SBATCH --gres=gpu:1       # 1 GPU per node (plus 100% of node CPU and RAM per node)
 
          # Run commands:
 
-         mpirun --bede-par 1ppc <mpi_program>
+         bede-mpirun --bede-par 1ppc <mpi_program>
 
          echo "end of job"
-
-      .. note:: 
-
-         Use on ``aarch64`` use ``mpirun`` rather than ``bede-mpirun`` when launching MPI applications
 
       .. note::
 
          There are only ``2`` ``gh`` nodes currently available for batch jobs in Bede. As a result multi-node Grace-Hopper jobs may queue for a significant time. 
 
+The ``bede-mpirun`` command takes both ordinary ``mpirun`` arguments and
+the special ``--bede-par <distrib>`` option, allowing control over how
+MPI jobs launch, e.g. one MPI rank per CPU core or GPU.
+
+The formal specification of the option is:
+``--bede-par <rank_distrib>[:<thread_distrib>]`` and it defaults to
+``1ppc:1tpt``
+
+Where ``<rank_distrib>`` can take ``1ppn`` (one process per node),
+``1ppg`` (one process per GPU), ``1ppc`` (one process per CPU core) or
+``1ppt`` (one process per CPU thread).
+
+And ``<thread_distrib>`` can take ``1tpc`` (set ``OMP_NUM_THREADS`` to
+the number of cores available to each process), ``1tpt`` (set
+``OMP_NUM_THREADS`` to the number of hardware threads available to each
+process) or ``none`` (set ``OMP_NUM_THREADS=1``)
+
+Examples:
+
+.. code-block:: bash
+
+   # - One MPI rank per node:
+   bede-mpirun --bede-par 1ppn <mpirun_options> <program>
+
+   # - One MPI rank per gpu:
+   bede-mpirun --bede-par 1ppg <mpirun_options> <program>
+
+   # - One MPI rank per core:
+   bede-mpirun --bede-par 1ppc <mpirun_options> <program>
+
+   # - One MPI rank per hwthread:
+   bede-mpirun --bede-par 1ppt <mpirun_options> <program>
+
+.. note:: 
+
+   On ``aarch64``, the ``--1ppt`` option is synonymous with ``--1ppc`` due to the absence of hardware SMT.
+
+.. _usage-maximum-job-runtime:
 
 Maximum Job Runtime
 ~~~~~~~~~~~~~~~~~~~
@@ -533,7 +532,7 @@ Key differences to be aware of include:
 * :ref:`software-compilers-gcc` compiling with ``--std=c++17`` may emit psABI warnings. These can be suppressed via ``--Wno-psabi``.
 * :ref:`MPI<software-libraries-MPI>`
 
-  * The ``openmpi`` module is available, and CUDA support is enabled if you additionally load a CUDA module. The ``mpirun`` command should be used to launch programs, and not the ``bede-mpirun`` command.
+  * The ``openmpi`` module is available, and CUDA support is enabled if you additionally load a CUDA module. The ``bede-mpirun`` command should be used to launch programs.
   * The ``ppc64le`` equipment has an MPI with optimised multi-node GPU communications provided by the ``mvapich2-gdr`` module. This is not available for the Grace Hopper equipment; however, we plan to provide a ``mvapich-plus`` module in future to provide this functionality. In the meantime, if this is of interest, please contact us.
 
 Bash environment

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -304,6 +304,42 @@ CPUs/GPUs across one or more machines:
 
          echo "end of job"
 
+
+      The ``bede-mpirun`` command takes both ordinary ``mpirun`` arguments and
+      the special ``--bede-par <distrib>`` option, allowing control over how
+      MPI jobs launch, e.g. one MPI rank per CPU core or GPU.
+
+      The formal specification of the option is:
+      ``--bede-par <rank_distrib>[:<thread_distrib>]`` and it defaults to
+      ``1ppc:1tpt``
+
+      Where ``<rank_distrib>`` can take ``1ppn`` (one process per node),
+      ``1ppg`` (one process per GPU), ``1ppc`` (one process per CPU core) or
+      ``1ppt`` (one process per CPU thread).
+
+      And ``<thread_distrib>`` can take ``1tpc`` (set ``OMP_NUM_THREADS`` to
+      the number of cores available to each process), ``1tpt`` (set
+      ``OMP_NUM_THREADS`` to the number of hardware threads available to each
+      process) or ``none`` (set ``OMP_NUM_THREADS=1``)
+
+      Examples:
+
+      .. code-block:: bash
+
+         # - One MPI rank per node:
+         bede-mpirun --bede-par 1ppn <mpirun_options> <program>
+
+         # - One MPI rank per gpu:
+         bede-mpirun --bede-par 1ppg <mpirun_options> <program>
+
+         # - One MPI rank per core:
+         bede-mpirun --bede-par 1ppc <mpirun_options> <program>
+
+         # - One MPI rank per hwthread:
+         bede-mpirun --bede-par 1ppt <mpirun_options> <program>
+
+      .. _usage-maximum-job-runtime:
+
    .. tab:: aarch64
 
       .. code-block:: bash
@@ -323,44 +359,14 @@ CPUs/GPUs across one or more machines:
 
          # Run commands:
 
-         bede-mpirun --bede-par 1ppc <mpi_program>
+         mpirun --bede-par 1ppc <mpi_program>
 
          echo "end of job"
 
-The ``bede-mpirun`` command takes both ordinary ``mpirun`` arguments and
-the special ``--bede-par <distrib>`` option, allowing control over how
-MPI jobs launch, e.g. one MPI rank per CPU core or GPU.
+      .. note:: 
 
-The formal specification of the option is:
-``--bede-par <rank_distrib>[:<thread_distrib>]`` and it defaults to
-``1ppc:1tpt``
+         Use on ``aarch64`` use ``mpirun`` rather than ``bede-mpirun`` when launching MPI applications
 
-Where ``<rank_distrib>`` can take ``1ppn`` (one process per node),
-``1ppg`` (one process per GPU), ``1ppc`` (one process per CPU core) or
-``1ppt`` (one process per CPU thread).
-
-And ``<thread_distrib>`` can take ``1tpc`` (set ``OMP_NUM_THREADS`` to
-the number of cores available to each process), ``1tpt`` (set
-``OMP_NUM_THREADS`` to the number of hardware threads available to each
-process) or ``none`` (set ``OMP_NUM_THREADS=1``)
-
-Examples:
-
-.. code-block:: bash
-
-   # - One MPI rank per node:
-   bede-mpirun --bede-par 1ppn <mpirun_options> <program>
-
-   # - One MPI rank per gpu:
-   bede-mpirun --bede-par 1ppg <mpirun_options> <program>
-
-   # - One MPI rank per core:
-   bede-mpirun --bede-par 1ppc <mpirun_options> <program>
-
-   # - One MPI rank per hwthread:
-   bede-mpirun --bede-par 1ppt <mpirun_options> <program>
-
-.. _usage-maximum-job-runtime:
 
 Maximum Job Runtime
 ~~~~~~~~~~~~~~~~~~~

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -262,7 +262,7 @@ Part of, or an entire node
 
 .. tabs::
 
-   .. tab:: ppc64le
+   .. group-tab:: ppc64le
 
       Example job script for programs written to take advantage of a GPU or
       multiple GPUs on a single ppc64le node:
@@ -293,7 +293,7 @@ Part of, or an entire node
          echo "end of job"
 
 
-   .. tab:: aarch64
+   .. group-tab:: aarch64
 
       Example job script for programs written to take advantage of single GPU on a single aarch64 node (1 GPU per node):
 
@@ -330,7 +330,7 @@ CPUs/GPUs across one or more machines:
 
 .. tabs::
 
-   .. tab:: ppc64le
+   .. group-tab:: ppc64le
 
       .. code-block:: bash
 
@@ -389,7 +389,7 @@ CPUs/GPUs across one or more machines:
 
       .. _usage-maximum-job-runtime:
 
-   .. tab:: aarch64
+   .. group-tab:: aarch64
 
       .. code-block:: bash
 

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -211,32 +211,67 @@ Requesting resources
 Part of, or an entire node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Example job script for programs written to take advantage of a GPU or
-multiple GPUs on a single computer:
+.. tabs::
 
-.. code-block:: bash
+   .. tab:: ppc64le
 
-   #!/bin/bash
+      Example job script for programs written to take advantage of a GPU or
+      multiple GPUs on a single ppc64le node:
 
-   # Generic options:
+      .. code-block:: bash
 
-   #SBATCH --account=<project>  # Run job under project <project>
-   #SBATCH --time=1:0:0         # Run for a max of 1 hour
+         #!/bin/bash
 
-   # Node resources:
-   # (choose between 1-4 gpus per node)
+         # Generic options:
 
-   #SBATCH --partition=gpu    # Choose either "gpu" or "infer" node type
-   #SBATCH --nodes=1          # Resources from a single node
-   #SBATCH --gres=gpu:1       # One GPU per node (plus 25% of node CPU and RAM per GPU)
+         #SBATCH --account=<project> # Run job under project <project>
+         #SBATCH --time=1:0:0        # Run for a max of 1 hour
 
-   # Run commands:
+         # Node resources:
+         # (choose between 1-4 gpus per node)
 
-   nvidia-smi  # Display available gpu resources
+         #SBATCH --partition=test    # Choose either "gpu", "test" or "infer" partition type
+         #SBATCH --nodes=1           # Resources from a single node
+         #SBATCH --gres=gpu:1        # One GPU per node (plus 25% of node CPU and RAM per GPU)
 
-   # Place other commands here
+         # Run commands:
 
-   echo "end of job"
+         nvidia-smi  # Display available gpu resources
+         nproc       # Display available CPU cores
+
+         # Place other commands here
+
+         echo "end of job"
+
+
+   .. tab:: aarch64
+
+      Example job script for programs written to take advantage of single GPU on a single aarch64 node (1 GPU per node):
+
+      .. code-block:: bash
+
+         #!/bin/bash
+
+         # Generic options:
+
+         #SBATCH --account=<project> # Run job under project <project>
+         #SBATCH --time=0:15:0       # Run for a max of 15 minutes
+
+         # Node resources:
+         # 1 gpu per node
+
+         #SBATCH --partition=ghtest  # Choose either "gh" or "ghtest"
+         #SBATCH --nodes=1           # Resources from a single node
+         #SBATCH --gres=gpu:1        # One GPU per node (plus 100% of node CPU and RAM per GPU)
+
+         # Run commands:
+
+         nvidia-smi  # Display available gpu resources
+         nproc       # Display available CPU cores
+
+         # Place other commands here
+
+         echo "end of job"
 
 Multiple nodes (MPI)
 ^^^^^^^^^^^^^^^^^^^^
@@ -244,26 +279,53 @@ Multiple nodes (MPI)
 Example job script for programs using MPI to take advantage of multiple
 CPUs/GPUs across one or more machines:
 
-.. code-block:: bash
+.. tabs::
 
-   #!/bin/bash
+   .. tab:: ppc64le
 
-   # Generic options:
+      .. code-block:: bash
 
-   #SBATCH --account=<project>  # Run job under project <project>
-   #SBATCH --time=1:0:0         # Run for a max of 1 hour
+         #!/bin/bash
 
-   # Node resources:
+         # Generic options:
 
-   #SBATCH --partition=gpu    # Choose either "gpu" or "infer" node type
-   #SBATCH --nodes=2          # Resources from a two nodes
-   #SBATCH --gres=gpu:4       # Four GPUs per node (plus 100% of node CPU and RAM per node)
+         #SBATCH --account=<project>  # Run job under project <project>
+         #SBATCH --time=1:0:0         # Run for a max of 1 hour
 
-   # Run commands:
+         # Node resources:
 
-   bede-mpirun --bede-par 1ppc <mpi_program>
+         #SBATCH --partition=gpu    # Choose either "gpu", "test" or "infer" partition type
+         #SBATCH --nodes=2          # Resources from two nodes
+         #SBATCH --gres=gpu:4       # Four GPUs per node (plus 100% of node CPU and RAM per node)
 
-   echo "end of job"
+         # Run commands:
+
+         bede-mpirun --bede-par 1ppc <mpi_program>
+
+         echo "end of job"
+
+   .. tab:: aarch64
+
+      .. code-block:: bash
+
+         #!/bin/bash
+
+         # Generic options:
+
+         #SBATCH --account=<project>  # Run job under project <project>
+         #SBATCH --time=1:0:0         # Run for a max of 1 hour
+
+         # Node resources:
+
+         #SBATCH --partition=gh    # Choose either "gh" or"ghtest" partition type
+         #SBATCH --nodes=2          # Resources from two nodes
+         #SBATCH --gres=gpu:1       # 1 GPU per node (plus 100% of node CPU and RAM per node)
+
+         # Run commands:
+
+         bede-mpirun --bede-par 1ppc <mpi_program>
+
+         echo "end of job"
 
 The ``bede-mpirun`` command takes both ordinary ``mpirun`` arguments and
 the special ``--bede-par <distrib>`` option, allowing control over how


### PR DESCRIPTION
Adds non-pilot grace-hopper specific documentation. 

Closes #185

+ [x] Usage page
    + [x] Add ghlogin partition detail
    + [x] Add CPU architecture/ Partitions subsection explaining which are which
    + [x] Reduce GH pilot subsection to be less content + links, stating that the pilot has ended. To be removed at a future date
+ [x] Add announcement stating 3 GH200 480GB nodes are now avialable
    + [x] link to a usage subsection?
+ [x] Remove wmlce documentation (via orphan)
+ [x] Add admonition to each ppc64le only page
+ [x] Add gh details to each software page
    + [x] Conda
    + [x] Python
      + [x] Check if python2 is still available. Change that bit to be architecture specific
      + [x] Make default python version information partition specific.
    + [x] pytorch
        + Include how to get a CUDA enabled build at the mo
    + [x] Rust - no changes needed
    + [x] Tensorflow
        + Include how to get a CUDA enabled build at the mo
    + [x] CUDA/NVCC
        + Modules, CUDA verisons & limitations, gencodes
    + [x] GCC
        + [x] mention psABI warnings and how to suppress.
        + [x] Double check / reprhase psabi docs
    + [x] NVHPC
    + [x] Blas/Lapack (OpenBLAS)
        + ~Maybe split this page into3. Current page and one per implementation so its clearer which are availabe on which platform.~ defferred to #192 
    + [x] Boost
    + [x] FFTW
    + [x] HDF5
    + [x] OpenMPI
        + ~Maybe split  MPI page so its clearer which is available where~ deferred to #191 
    + [x] NVTX
    + [x] CMake (no modules)
    + [x] Make
    + [x] `ncu`
      + [x] add version info 
    + [x] `nsys`
      + [x] add version info
    + [x] `nvidia-smi`
    + [x] Apptainer/Singularity documentation. 
        + Current plan is for ppc64le to continue with singularity to avoid unneccesary breaking changes
        + [x] Apptainer page - just aarch64, cross ref singularity CE. Mention fakeroot.
        + [x] Singularity - rename singularity CE. ppc64le only. Cross ref Apptainer 
+ [x] Add arch bash detection for .bashrc to faq and usage.
+ [x] Basic tabs theme customisation
+ [x] Finished tabs theme customisation (code tabs don't look great) 
+ Guides
   + ~Add a guide for running a pytorch workflow on gracehopper as an example?~ Deffered to #193
   + This might be deffered to a separate issue
+ [x] sidebar and non-sidebar common admonitions and use the. 