### PR TITLE
aarch64: Add Pytorch pip installation instructions for nightly 2.4/2.5

### DIFF
--- a/software/applications/pytorch.rst
+++ b/software/applications/pytorch.rst
@@ -10,6 +10,8 @@ The main method of distribution for PyTorch for ``ppc64le`` is via :ref:`Conda <
 
 The upstream Conda and pip distributions do not provide ppc64le pytorch packages at this time. 
 
+.. _software-applications-pytorch-conda:
+
 Installing via Conda
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -67,8 +69,69 @@ Installing via Conda
 
       .. warning::
 
-         Conda builds of PyTorch for ``aarch64`` do not include CUDA support as of April 2024. For now, see :ref:`software-applications-pytorch-ngc` or `build from source <https://pytorch.org/get-started/locally/#linux-from-source>`__.
+         Conda builds of PyTorch for ``aarch64`` do not include CUDA support as of June 2024. This may change with the upcoming PyTorch ``2.4`` release `scheduled for July 2024 <https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence>`__.
          
+         For now, consider:
+         
+         * Install a ``2.4.0`` or ``2.5.0`` pre-release build using the CUDA 12.4 PyTorch nightly channel via pip (see :ref:`software-applications-pytorch-pip`)
+         * `Build PyTorch from source <https://pytorch.org/get-started/locally/#linux-from-source>`__ into a conda environment.
+         * Use containers provided by Nvidia for a pip-based environment (see :ref:`software-applications-pytorch-ngc`)
+         
+
+.. _software-applications-pytorch-pip:
+
+Installing via pip
+~~~~~~~~~~~~~~~~~~
+
+.. tabs::
+
+   .. group-tab:: ppc64le
+
+      .. warning::
+
+         ``pip`` does not provide ``ppc64le`` builds of PyTorch (from PyPI or the PyTorch wheel repositories). Instead, see :ref:`software-applications-pytorch-conda` or `build from source <https://pytorch.org/get-started/locally/#linux-from-source>`__.
+
+   .. group-tab:: aarch64
+
+      PyTorch pip packages for ``aarch64`` prior to PyTorch ``2.4`` do not include CUDA support.
+
+      This should change with the upcoming PyTorch ``2.4`` release `scheduled for July 2024 <https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-cadence>`__.
+
+      Currently (June 2024), nightly pre-release ``aarch64`` builds of PyTorch ``2.4`` and ``2.5`` with CUDA 12.4 support can be installed via pip.
+     
+      .. warning::
+
+         * These are nightly pre-release builds, which are not fully tested or supported by PyTorch.
+         * CUDA 11.8 and CUDA 12.1 nightly ``aarch64`` builds do not include CUDA support. You must use the CUDA 12.4 repository.
+         * Nightly CUDA 12.4 wheels are currently large (over 2GB). Consider creating your ``venv`` / conda env in ``/nobackup`` to avoid filling your home directory quota.
+         * As with other PyTorch ``2.x`` builds, you may see a warning if you do not also install ``numpy`` into your python environment.
+      
+      .. code-block:: bash
+
+         # Create a python venv in /nobackup, replacing your project name and following path as appropriate
+         python3 -m venv /nobackup/projects/bdXXXXX/pytorch-nightly-venv
+
+         # Activate the venv, replacing the path as appropriate
+         source /nobackup/projects/bdXXXXX/pytorch-nightly-venv/bin/activate
+
+         # Install the latest nightly pre release using the CUDA 12.4 nightly repository
+         python3 -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu124
+
+         # Ensure that CUDA support is enabled
+         python3 -c "import torch; print(torch.__version__); print(torch.cuda.is_available());)"
+
+      In subsequent interactive sessions, and when submitting batch jobs which use PyTorch, you will then need to re-source the python venv.
+
+      For example, to verify that PyTorch is available and print the version:
+
+      .. code-block:: bash
+
+         # Activate the venv, replacing the path as appropriate
+         source /nobackup/projects/bdXXXXX/pytorch-nightly-venv/bin/activate
+
+         # Invoke python
+         python3 -c "import torch; print(torch.__version__)"
+
 .. _software-applications-pytorch-ngc:
 
 Using NGC PyTorch Containers


### PR DESCRIPTION
Nightly CUDA 12.4 builds of PyTorch 2.4 and 2.5 for aarch64 with CUDA support can be installed via pip.

Once 2.4 is released at some point in July 2024, it should be possible to install from the non-nightly channel, hopefully for CUDA 11.8 and 12.1, and hopefully via conda.

These instructions are added as a temporary work around after a user enquiry

Related to #199