### PR TITLE
Add weekly login node at risk period to usage

### DIFF
--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -7,7 +7,7 @@ This does not currently support linking outside of the documentation website.
  window.onload = function () {
     expectedAnnouncementContent = "Using Bede";
     expectedAnchorContent = "Using Bede";
-    optionalTargetID = "grace-hopper-pilot"; // null if linking to page
+    optionalTargetID = "usage-weekly-at-risk"; // null if linking to page
     fullAnnouncementAnchor = false;
     var elements = document.getElementsByClassName("bd-header-announcement");
     for (var i = 0; i < elements.length; i++) {

--- a/conf.py
+++ b/conf.py
@@ -94,7 +94,7 @@ html_theme_options = {
     # Code highlighting theme for dark mode
     "pygment_dark_style": "github-dark-high-contrast",
     # Add an announcement bar, visible at the top of each page.
-    "announcement": "3 additional (6 total) NVIDIA Grace-Hopper nodes (GH200 480) are now available. See Using Bede",
+    "announcement": "Weekly login-node \"at risk\" period 8am-10am on Tuesdays. See Using Bede",
     # Add the traditional footer theme and sphinx acknowledgements
     "extra_footer": f"<p>&nbsp;Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>.</p>"
 }

--- a/usage/index.rst
+++ b/usage/index.rst
@@ -29,11 +29,15 @@ fronts the two ``ppc64le`` login nodes, ``login1.bede.dur.ac.uk`` and
 ``login2.bede.dur.ac.uk``). SSH or X2GO should be used for all interaction with
 the machine (including shell access, file transfer and graphics).
 
-.. warning::
+.. important::
 
    Please use an SSH client and **not** X2GO the first time you ever log in to
    Bede, or immediately after a password reset. Your MFA token will be
    generated, but X2GO will not show it to you.
+
+.. warning::
+
+   Login nodes are subject to a weekly "at risk" period every Tuesday from 08:00 to 10:00 (from 2025-02-25). See :ref:`usage-weekly-at-risk` for more details.
 
 The login nodes are shared between all users of the service and
 therefore should only be used for light interactive work, for example:
@@ -84,6 +88,27 @@ please contact `support <../faq/#faq-helpsupport>`__ for options.
 **If you have lost your password or MFA token, please use EPCC's SAFE system to request a password reset for your Bede login account, which we normally aim to process within a working day.**
 
 If you are finding that you are having to use your password and a MFA token too many times, we have provided some tips on `how to reduce the frequency that MFA is required <../faq/#faq-reducemfa>`__.
+
+.. _usage-weekly-at-risk:
+
+Weekly "at risk" period for login nodes
+---------------------------------------
+
+A weekly "at risk" period has been introduced for Bede's login nodes, every Tuesday morning from 8am to 10am (from 2025-02-25) for regular maintenance tasks.
+
+This will sometimes involve interruptions, such as a reboot, in which case logged-in users will be warned on their terminal screen shortly before they are disconnected.
+
+During this time:
+
+* *Login sessions* and so *interactive jobs* may be ended.
+* *File transfers* to (or from) Bede may be ended.
+* Batch jobs and compute nodes will continue to run as normal.
+
+Why we are doing this:
+
+* The timely application of security updates is increasingly important. The new "at risk" period will help us keep Bede and your work secure.
+* The login nodes fill up with mislaid user processes over time, increasing load and slowing down your work. The new "at risk" policy will help improve Bede's interactive performance.
+* The new "at risk" period will reduce the number of routine emails we send, which will help your Inbox.
 
 .. _usage-x2go:
 


### PR DESCRIPTION
- New section on usage about the weekly at risk period
- Annoucnment now hihglights the at risk period
- New warning in the 'Login' section of the usage docs with an xref
- Adjusts previous warning in 'Login' section to Important

Closes #212