### PR TITLE
Add short ghlogin change notification announcment. 

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -94,7 +94,7 @@ html_theme_options = {
     # Code highlighting theme for dark mode
     "pygment_dark_style": "github-dark-high-contrast",
     # Add an announcement bar, visible at the top of each page.
-    "announcement": "Weekly login-node \"at risk\" period 8am-10am on Tuesdays. See Using Bede",
+    "announcement": "The Grace Hopper login node (accessed via the \"ghlogin\" command) will be replaced at 9am on Tue 23rd September.<br />If you need access to a GPU in the Grace Hopper environment for testing after this time, please submit to the priority \"ghtest\" queue.",
     # Add the traditional footer theme and sphinx acknowledgements
     "extra_footer": f"<p>&nbsp;Built with <a href=\"http://sphinx-doc.org/\">Sphinx</a> {sphinx.__version__} using a theme by the <a href=\"https://ebp.jupyterbook.org/\">Executable Book Project</a>.</p>"
 }


### PR DESCRIPTION
Add short ghlogin change notification announcment. 

Should be reverted / changed on the 23rd of september when the change is made and #221 is merged.

<img width="952" height="78" alt="image" src="https://github.com/user-attachments/assets/0dab82ea-6d10-4d8a-98b6-cbc1a826b7c7" />
